### PR TITLE
Query the GHC run-time version via hie-bios

### DIFF
--- a/ghc-debug-adapter/Development/Debug/Adapter/Exit.hs
+++ b/ghc-debug-adapter/Development/Debug/Adapter/Exit.hs
@@ -80,12 +80,12 @@ exitCleanupWithMsg final_handle msg = do
   exitWithMsg msg
 
 -- | Logs the error to the debug console and sends a terminate event
-exitWithMsg :: String -> DebugAdaptor ()
+exitWithMsg :: String -> DebugAdaptor a
 exitWithMsg msg = do
   Output.important (T.pack msg)
   exitCleanly
 
-exitCleanly :: DebugAdaptor ()
+exitCleanly :: DebugAdaptor a
 exitCleanly = do
 
   sendTerminatedEvent (TerminatedEvent False)


### PR DESCRIPTION
The GHC debugger is only ever be used in a project that is compiled with exactly the same GHC binary, as the GHC debugger.

We check the version of the GHC version used to compile a project with against the version the GHC debugger has been compiled with. The GHC on PATH is not always the GHC version that is used in a project to develop.
For example, in a `cabal.project` file, the user could change the used GHC binary with `with-compiler: ...` entries.
Thus, we use the GHC version as specified by the `Cradle` to determine the run-time GHC version.

For now, we only check the major and minor version of run-time and compile-time GHC. This will likely change in the future.

Closes #25 

Checked manually that the tests still succeed.