### PR TITLE
fix: changed  default config settings for missing launch.json case.

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -175,7 +175,7 @@
               "request": "launch",
               "name": "Haskell Debugger",
               "projectRoot": "^\"\\${workspaceFolder}\"",
-              "entryFile": "app/Main.hs",
+              "entryFile": "^\"\\${file}\"",
               "entryPoint": "main",
               "entryArgs": [],
               "extraGhcArgs": []

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -260,11 +260,12 @@ class GHCConfigurationProvider implements vscode.DebugConfigurationProvider {
 		// if launch.json is missing or empty
 		if (!config.type && !config.request && !config.name) {
 			const editor = vscode.window.activeTextEditor;
-			if (editor && editor.document.languageId === 'markdown') {
+			if (editor && editor.document.languageId === 'haskell') {
 				config.type = 'haskell-debugger';
 				config.name = 'Launch';
 				config.request = 'launch';
 				config.entryFile = '${file}';
+				config.projectRoot = '${workspaceFolder}';
 				config.entryPoint = 'main';
 				config.entryArgs = [];
 				config.extraGhcArgs = [];


### PR DESCRIPTION
Changes the default configuration to start the debugger if launch.json does not exist.