### PR TITLE
Improve launch defaults and failure message

### DIFF
--- a/hdb/Development/Debug/Adapter/Exit.hs
+++ b/hdb/Development/Debug/Adapter/Exit.hs
@@ -71,7 +71,7 @@ exitCleanupWithMsg
   -- killing the output thread with @destroyDebugSession@)
   -> String
   -- ^ Error message, logged with notification
-  -> DebugAdaptor ()
+  -> DebugAdaptor a
 exitCleanupWithMsg final_handle msg = do
   destroyDebugSession -- kill all session threads (including the output thread)
   do                  -- flush buffer and get all pending output from GHC

--- a/test/integration-tests/data/T71/Main.hs
+++ b/test/integration-tests/data/T71/Main.hs
@@ -1,0 +1,2 @@
+main = do
+  putStrLn "T71 is running!"


### PR DESCRIPTION
Make all launch settings have a sensible default except for "entryFile" which is always required.

When "entryFile" is not provided, the error should be correctly reported via an ErrorResponse message.

Fixes #71