### PR TITLE
Expand Terms as they the user expands them

### DIFF
--- a/haskell-debugger/GHC/Debugger/Stopped/Variables.hs
+++ b/haskell-debugger/GHC/Debugger/Stopped/Variables.hs
@@ -43,6 +43,9 @@ tyThingToVarInfo t = case t of
     termToVarInfo key term
 
 -- | Construct the VarInfos of the fields ('VarFields') of the given 'TermKey'/'Term'
+--
+-- This is used to come up with terms for the fields of an already `seq`ed
+-- variable which was expanded.
 termVarFields :: TermKey -> Term -> Debugger VarFields
 termVarFields top_key top_term =
 

--- a/test/integration-tests/data/T97/Main.hs
+++ b/test/integration-tests/data/T97/Main.hs
@@ -1,0 +1,13 @@
+module Main where
+
+data T97 a = T97 a
+  deriving Show
+
+
+main = do
+  let y :: T97 (T97 (T97 (T97 (T97 (T97 String)))))
+      y = T97 (T97 (T97 (T97 (T97 (T97 "hello")))))
+
+  print y
+  print y
+

--- a/test/integration-tests/flake.lock
+++ b/test/integration-tests/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756128520,
-        "narHash": "sha256-R94HxJBi+RK1iCm8Y4Q9pdrHZl0GZoDPIaYwjxRNPh4=",
+        "lastModified": 1760139962,
+        "narHash": "sha256-4xggC56Rub3WInz5eD7EZWXuLXpNvJiUPahGtMkwtuc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c53baa6685261e5253a1c355a1b322f82674a824",
+        "rev": "7e297ddff44a3cc93673bb38d0374df8d0ad73e4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/test/integration-tests/flake.nix
+++ b/test/integration-tests/flake.nix
@@ -2,7 +2,7 @@
   description = "Integration tests for hdb";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable"; # or unstable
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05"; # or unstable
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
The defaultDepth to which we expand Ids is low because otherwise the performance cost is too great and perceivably slow.

However, the user has to iteractively expand the branches of the representation tree of variables as they want to view them.

We can leverage this interactivity to overcome the limited depth to which we expand. Simply: when the user expands a variable, always expand its corresponding Term a little bit more.

Fixes #97