### PR TITLE
Add hlint config and github action

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,30 @@
+# Warnings currently triggered by your code
+- ignore: {name: "Eta reduce"} # 8 hints
+- ignore: {name: "Evaluate"} # 4 hints
+- ignore: {name: "Fuse mapM/map"} # 1 hint
+- ignore: {name: "Move brackets to avoid $"} # 2 hints
+- ignore: {name: "Redundant $"} # 4 hints
+- ignore: {name: "Redundant <$>"} # 1 hint
+- ignore: {name: "Redundant bracket"} # 23 hints
+- ignore: {name: "Redundant lambda"} # 2 hints
+- ignore: {name: "Redundant return"} # 3 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 33 hints
+- ignore: {name: "Use $>"} # 1 hint
+- ignore: {name: "Use <$>"} # 4 hints
+- ignore: {name: "Use camelCase"} # 4 hints
+- ignore: {name: "Use elemIndex"} # 1 hint
+- ignore: {name: "Use exitSuccess"} # 2 hints
+- ignore: {name: "Use fewer LANGUAGE pragmas"} # 5 hints
+- ignore: {name: "Use fewer imports"} # 1 hint
+- ignore: {name: "Use handle"} # 1 hint
+- ignore: {name: "Use list comprehension"} # 1 hint
+- ignore: {name: "Use mapMaybe"} # 2 hints
+- ignore: {name: "Use maybeToList"} # 1 hint
+- ignore: {name: "Use newtype instead of data"} # 10 hints
+- ignore: {name: "Use null"} # 1 hint
+- ignore: {name: "Use optional"} # 1 hint
+- ignore: {name: "Use or"} # 1 hint
+- ignore: {name: "Use print"} # 5 hints
+- ignore: {name: "Use record patterns"} # 1 hint
+- ignore: {name: "Use uncurry"} # 2 hints
+- ignore: {name: "Use unless"} # 2 hints

--- a/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
+++ b/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OrPatterns #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE QualifiedDo #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE LambdaCase #-}
@@ -181,10 +182,10 @@ bcoBreakPointInfoParser = do
           | otherwise = 0 :: Int
 
     let find_ixs_fv = Remote.raw $
-          "\\x -> let index_at n = GHC.Word.W16# (GHC.Base.indexWord16Array# x (n GHC.Exts.+# " ++ show bRK_FUN_offset ++ "#)) " ++
-                   "in if (index_at 0# Data.Bits..&. 0xFF) == 66{-bci_BRK_FUN-} then \
-                        Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#) \
-                      else Nothing"
+          "\\x -> let index_at n = GHC.Word.W16# (GHC.Base.indexWord16Array# x (n GHC.Exts.+# " ++ show bRK_FUN_offset ++ """#))
+                    in if (index_at 0# Data.Bits..&. 0xFF) == 66{-bci_BRK_FUN-} then
+                        Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#)
+                      else Nothing"""
     rs_fv <- expectRight =<< Remote.eval
       (find_ixs_fv `Remote.app` Remote.untypedRef instrs_array_fv)
 


### PR DESCRIPTION
What an awesome addition to the Haskell toolset.

I tried configuring the project for linting and found remarkably few suggestions, all currently ignored. I exclude one module that doesn't parse.

Are you up for enabling `-XMultilineStrings`? If so I can get HLint to parse that module with this change:

```diff
$ git diff
diff --git a/.hlint.yaml b/.hlint.yaml
index 8b68b50..52eea92 100644
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,5 +26,3 @@
 - ignore: {name: "Use record patterns"} # 1 hint
 - ignore: {name: "Use uncurry"} # 2 hints
 - ignore: {name: "Use unless"} # 2 hints
-- arguments:
-    - --ignore-glob=haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
diff --git a/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs b/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
index 3eeca85..23441df 100644
--- a/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
+++ b/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE MultilineStrings #-}
 
 -- | Decoding the stack of a thread at runtime
 module GHC.Debugger.Runtime.Thread.Stack
@@ -181,10 +182,10 @@ bcoBreakPointInfoParser = do
           | otherwise = 0 :: Int
 
     let find_ixs_fv = Remote.raw $
-          "\\x -> let index_at n = GHC.Word.W16# (GHC.Base.indexWord16Array# x (n GHC.Exts.+# " ++ show bRK_FUN_offset ++ "#)) " ++
-                   "in if (index_at 0# Data.Bits..&. 0xFF) == 66{-bci_BRK_FUN-} then \
-                        Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#) \
-                      else Nothing"
+          "\\x -> let index_at n = GHC.Word.W16# (GHC.Base.indexWord16Array# x (n GHC.Exts.+# " ++ show bRK_FUN_offset ++ """#))
+                    in if (index_at 0# Data.Bits..&. 0xFF) == 66{-bci_BRK_FUN-} then
+                        Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#)
+                      else Nothing"""
     rs_fv <- expectRight =<< Remote.eval
       (find_ixs_fv `Remote.app` Remote.untypedRef instrs_array_fv)

```