### PR TITLE
Add support for building project packages with Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ vscode-extension/dist/
 vscode-extension/result
 dist-newstyle/
 cabal.project.local
+
+# Stack-related
+.stack-work
+*.yaml.lock

--- a/README.md
+++ b/README.md
@@ -149,12 +149,28 @@ built-in version in memory.
 
 # Building from source
 
-To build `hdb`:
+## Build `hdb` (using Cabal)
+
 ```
 cabal build -w /path/to/ghc-9.14 exe:hdb
 ```
 
-To build the VSCode extension
+## Build and install `hdb` (using Stack)
+
+On non-Windows operating systems:
+
+```
+stack install haskell-debugger
+```
+
+On Windows:
+
+```
+stack -w stack-windows.yaml install haskell-debugger
+```
+
+## Build VS Code extension (using Nix)
+
 ```
 cd vscode-extension
 nix-build

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,0 +1,13 @@
+# A bespoke snapshot for GHC 9.14.1. There is no Stackage snapshot for
+# GHC 9.14.1.
+#
+# The relevant package versions in this snapshot are known, by testing, to work
+# together, not withstanding the upper bounds on dependencies specified in their
+# Cabal files.
+snapshot: nightly-2026-01-10 # GHC 9.12.3.
+compiler: ghc-9.14.1
+
+# Not in nightly-2026-01-10:
+packages:
+- dap-0.3.1.0@sha256:2e3f360463bba05cb062e764ae0dd958dba0ad67e83791e0d6d5adb3d259539a,2324
+- implicit-hie-0.1.4.0@sha256:42a8bdc36713d98711c59b62fac238d81f6ce3ef7912752f38d456182260a5a3,3122

--- a/stack-windows.yaml
+++ b/stack-windows.yaml
@@ -1,0 +1,7 @@
+# Stack project-level configuration for Windows only.
+
+snapshot: snapshot.yaml
+
+packages:
+- .
+- haskell-debugger-view

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,12 @@
+# Stack project-level configuration for non-Windows operating systems only.
+
+snapshot: snapshot.yaml
+
+packages:
+- .
+- haskell-debugger-view
+
+# Applicable only to non-Windows operating systems:
+configure-options:
+  haskell-debugger:
+  - --enable-executable-dynamic


### PR DESCRIPTION
Adds a GHC 9.14.1-friendly snapshot and two configuration files (non-Windows (default) and Windows). This will facilitate Stack users building the executable from the repository.

Updates `README.md`, accordingly.

Also updates `.gitignore` to avoid Stack-related build artefacts.