### PR TITLE
Disambiguate more Just/Nothing in raw eval strings

### DIFF
--- a/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
+++ b/haskell-debugger/GHC/Debugger/Runtime/Thread/Stack.hs
@@ -211,8 +211,8 @@ bcoBreakPointInfoParser = do
     let find_ixs_fv = Remote.raw $
           "\\x -> let index_at n = GHC.Word.W16# (GHC.Base.indexWord16Array# x (n GHC.Exts.+# " ++ show bRK_FUN_offset ++ """#))
                     in if (index_at 0# Data.Bits..&. 0xFF) == 66{-bci_BRK_FUN-} then
-                        GHC.Internal.Maybe.Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#)
-                      else GHC.Internal.Maybe.Nothing"""
+                        Data.Maybe.Just (index_at 1#, index_at 2#, index_at 3#, index_at 4#, index_at 5#)
+                      else Data.Maybe.Nothing"""
     rs_fv <- expectRight =<< Remote.eval
       (find_ixs_fv `Remote.app` Remote.untypedRef instrs_array_fv)
 


### PR DESCRIPTION
Otherwise, Just/Nothing occurrences in raw strings are ambiguous with user modules like GHC's Strict Maybe