### PR TITLE
exceptions: Qualify SomeException in raw eval strings

### DIFF
--- a/haskell-debugger/GHC/Debugger/Stopped/Exception.hs
+++ b/haskell-debugger/GHC/Debugger/Stopped/Exception.hs
@@ -155,10 +155,10 @@ exceptionInfoData =
 -- populates the 'ExceptionInfoNode' structure.
 exceptionInfoExpr :: String
 exceptionInfoExpr = """
-  let collectExceptionInfo :: SomeException -> ExceptionInfoNode
+  let collectExceptionInfo :: Control.Exception.SomeException -> ExceptionInfoNode
       collectExceptionInfo se' =
         case se' of
-          SomeException exc ->
+          Control.Exception.SomeException exc ->
             let ctx = Control.Exception.someExceptionContext se'
                 rendered = Control.Exception.Context.displayExceptionContext ctx
                 whileHandling = Control.Exception.Context.getExceptionAnnotations ctx


### PR DESCRIPTION
Otherwise they may not be in scope and not found.