### PR TITLE
Allow internal-interpreter to be configured on launch args

### DIFF
--- a/test/integration-tests/test/adapter.test.ts
+++ b/test/integration-tests/test/adapter.test.ts
@@ -286,6 +286,20 @@ describe("Debug Adapter Tests", function () {
                 const expected = { path: config.projectRoot + "/" + config.entryFile, line: 2 }
                 return dc.hitBreakpoint(config, { path: config.entryFile, line: 2 }, expected, expected)
             })
+
+            it('accepts internalInterpreter launch option', async () => {
+                const config = mkConfig({
+                    projectRoot: "/data/simple",
+                    entryFile: "Main.hs",
+                    entryPoint: "main",
+                    entryArgs: [],
+                    extraGhcArgs: [],
+                    internalInterpreter: true
+                });
+
+                const expected = { path: config.projectRoot + "/" + config.entryFile, line: 6 };
+                return dc.hitBreakpoint(config, { path: config.entryFile, line: 6 }, expected, expected);
+            })
         })
 
     })

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -160,6 +160,11 @@
                 "type": "array",
                 "description": "Additional arguments to pass to the GHC invocation inferred by hie-bios for this project",
                 "default": []
+              },
+              "internalInterpreter": {
+                "type": "boolean",
+                "description": "Whether to use the internal GHCi interpreter for debugging.",
+                "default": false
               }
             }
           }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -186,7 +186,11 @@ class GHCDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescr
 		const serverExecutable = vscode.workspace.getConfiguration('haskell-debugger').get<string>('serverExecutable') || 'hdb';
 		this.logger.appendLine(`[Factory] Using server executable: ${serverExecutable}`);
 
-		const debuggerProcess = cp.spawn(serverExecutable, ['server', '--port', port.toString()]);
+		const debuggerProcess = cp.spawn(serverExecutable, [
+			'server',
+			'--port', port.toString(),
+			...(session.configuration.internalInterpreter ? ['--internal-interpreter'] : [])
+		]);
 
         debuggerProcess.on('spawn', () => {
             this.logger.appendLine('[Factory] haskell-debugger spawned...');


### PR DESCRIPTION
Adds `internalInterpreter` to launch configuration in VSCode