### PR TITLE
Display all threads by default

### DIFF
--- a/hdb/Development/Debug/Adapter/Evaluation.hs
+++ b/hdb/Development/Debug/Adapter/Evaluation.hs
@@ -109,7 +109,7 @@ handleEvalResult stepping er = case er of
   EvalStopped {breakId = Nothing, breakThread} ->
     sendStoppedEvent
       defaultStoppedEvent {
-        stoppedEventAllThreadsStopped = True
+        stoppedEventAllThreadsStopped = False
       , stoppedEventReason = StoppedEventReasonException
       , stoppedEventHitBreakpointIds = []
       , stoppedEventThreadId = Just $ remoteThreadIntRef breakThread
@@ -118,7 +118,7 @@ handleEvalResult stepping er = case er of
     DAS{breakpointMap} <- getDebugSession
     sendStoppedEvent
       defaultStoppedEvent {
-        stoppedEventAllThreadsStopped = True
+        stoppedEventAllThreadsStopped = False
          -- could be more precise here by saying "function breakpoint" rather than always "breakpoint"
       , stoppedEventReason
           = if stepping then StoppedEventReasonStep

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -185,7 +185,7 @@ getConfig port = do
       , supportsSteppingGranularity           = False
       , supportsInstructionBreakpoints        = False
       , supportsExceptionFilterOptions        = False
-      , supportsSingleThreadExecutionRequests = False
+      , supportsSingleThreadExecutionRequests = True
       }
   ServerConfig
     <$> do fromMaybe hostDefault <$> lookupEnv "DAP_HOST"


### PR DESCRIPTION
- We display all the threads in the debuggee process, except for ...
- When using the internal interpreter, the debuggee process and debugger process are the same. Therefore, we'll also see the debugger threads in that case. That's fine, it's observing the actual threads of the process being debugged.