### PR TITLE
logger: Output HieBios configuration to DAP console

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -159,6 +159,7 @@ executable hdb
 
         haskell-debugger,
         hie-bios,
+        prettyprinter ^>= 1.7.0,
         co-log-core >= 0.3.2.5 && < 0.4,
         implicit-hie ^>=0.1.4.0,
         transformers >= 0.6 && < 0.7,

--- a/hdb/Development/Debug/Session/Setup.hs
+++ b/hdb/Development/Debug/Session/Setup.hs
@@ -11,6 +11,7 @@ module Development.Debug.Session.Setup
 
   -- * Logging
   , SessionSetupLog(..)
+  , renderSessionSetupLog
   ) where
 
 import Control.Applicative ((<|>))
@@ -43,12 +44,20 @@ import qualified Hie.Locate as Implicit
 import qualified Hie.Yaml as Implicit
 
 import Colog.Core
+import Prettyprinter
+import Prettyprinter.Render.Text
 
 data SessionSetupLog
   = HieBiosLog HIE.Log
   | LogCradle (HIE.Cradle Void)
   | LogSetupMsg T.Text
   deriving Show
+
+renderSessionSetupLog :: SessionSetupLog -> T.Text
+renderSessionSetupLog = \case
+  HieBiosLog l -> renderStrict $ layoutPretty defaultLayoutOptions $ pretty l
+  LogCradle c -> T.pack $ "Using cradle: " ++ show c
+  LogSetupMsg m -> m
 
 -- | Flags inferred by @hie-bios@ to invoke GHC
 data HieBiosFlags = HieBiosFlags

--- a/test/haskell/Test/DAP/RunInTerminal.hs
+++ b/test/haskell/Test/DAP/RunInTerminal.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE CPP #-}
 module Test.DAP.RunInTerminal (runInTerminalTests) where
 
+import Control.Monad
 import Control.Concurrent
 import DAP.Types
 import DAP.Utils
@@ -112,12 +113,10 @@ runInTerminal1 flags = do
             ]
         ]
 
-      _ <- shouldReceive handle
-            ["type" .= ("event" :: String), "event" .= ("output" :: String)]
-      _ <- shouldReceive handle
-            ["type" .= ("event" :: String), "event" .= ("output" :: String)]
-      _ <- shouldReceive handle
-            ["type" .= ("event" :: String), "event" .= ("output" :: String)]
+      -- Receive output events
+      forM_ [1..9] $ \_ ->
+        shouldReceive handle
+          ["type" .= ("event" :: String), "event" .= ("output" :: String)]
       _ <- shouldReceive handle
             [ "command" .= ("launch" :: String)
             , "success" .= True]


### PR DESCRIPTION
This ensures that HieBios messages get output to the DAP console which the user can see by default.

This is important since these steps may take a long while and the debugger will appear unresponsive otherwise.