### PR TITLE
Enable IPE backtraces by default for better crash diagnostics

### DIFF
--- a/hdb/Development/Debug/Options.hs
+++ b/hdb/Development/Debug/Options.hs
@@ -8,13 +8,14 @@ import Colog.Core (Severity)
 
 -- | The options `hdb` is invoked in the command line with
 data HdbOptions
-  -- | @server [--internal-interpreter] --port <port>@
+  -- | @server [--internal-interpreter] [--disable-ipe-backtraces] --port <port>@
   = HdbDAPServer
     { port :: Int
     , verbosity :: Severity
     , internalInterpreter :: Bool
+    , disableIpeBacktraces :: Bool
     }
-  -- | @cli [--internal-interpreter] [--entry-point=<entryPoint>] [--extra-ghc-args="<args>"] [<entryFile>] -- [<entryArgs>]@
+  -- | @cli [--internal-interpreter] [--disable-ipe-backtraces] [--entry-point=<entryPoint>] [--extra-ghc-args="<args>"] [<entryFile>] -- [<entryArgs>]@
   | HdbCLI
     { entryPoint :: String
     , entryFile :: FilePath
@@ -22,6 +23,7 @@ data HdbOptions
     , extraGhcArgs :: [String]
     , verbosity :: Severity
     , internalInterpreter :: Bool
+    , disableIpeBacktraces :: Bool
     , debuggeeStdin :: Maybe FilePath
     }
 

--- a/hdb/Development/Debug/Options/Parser.hs
+++ b/hdb/Development/Debug/Options/Parser.hs
@@ -29,6 +29,7 @@ serverParser = HdbDAPServer
      <> help "DAP server port" )
   <*> verbosityParser Debug
   <*> internalInterpreterParser
+  <*> disableIpeBacktracesParser
 
 -- | Parser for 'HdbCLI' options
 cliParser :: Parser HdbOptions
@@ -55,6 +56,7 @@ cliParser = HdbCLI
      <> help "Additional flags to pass to the ghc invocation that loads the program for debugging" )
   <*> verbosityParser Warning
   <*> internalInterpreterParser
+  <*> disableIpeBacktracesParser
   <*> (optional $ strOption
       ( long "debuggee-stdin"
      <> metavar "FILE"
@@ -151,6 +153,22 @@ internalInterpreterParser =
   switch
     ( long "internal-interpreter"
    <> help "Prefer running the debuggee on the debugger's internal interpreter rather than on a separate (external-interpreter) process"
+    )
+
+-- | Parser for --disable-ipe-backtraces
+--
+-- Disable IPE backtrace information in the debugger. By default, IPE backtraces
+-- are enabled to provide better crash diagnostics when debugging Haskell programs.
+-- However, when using the internal interpreter, IPE backtraces appear in the
+-- debugger output but not with the external interpreter (since they run as
+-- separate processes). Use this flag only if you need consistent test output
+-- between internal and external interpreter modes, or when testing behavior that
+-- should not include IPE backtrace information.
+disableIpeBacktracesParser :: Parser Bool
+disableIpeBacktracesParser =
+  switch
+    ( long "disable-ipe-backtraces"
+   <> help "Disable IPE backtrace info for consistent output between internal/external interpreter modes"
     )
 
 -- | Main parser info

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -55,7 +55,6 @@ main :: IO ()
 main = do
   setBacktraceMechanismState CostCentreBacktrace False
   setBacktraceMechanismState HasCallStackBacktrace True
-  setBacktraceMechanismState IPEBacktrace False -- TODO: True, see #181
 
   allArgs <- getArgs
   hdbOpts <- case allArgs of
@@ -66,7 +65,8 @@ main = do
          pure (HdbExternalInterpreter (read writeFd) (read readFd))
     _ -> parseHdbOptions
   case hdbOpts of
-    HdbDAPServer{port, internalInterpreter} -> do
+    HdbDAPServer{port, internalInterpreter, disableIpeBacktraces} -> do
+      setBacktraceMechanismState IPEBacktrace (not disableIpeBacktraces)
       config <- getConfig port
       redirectRealStdout internalInterpreter $ \realStdout -> do
         hSetBuffering realStdout LineBuffering
@@ -78,6 +78,7 @@ main = do
           (talk l init_var pid_var ccon_var internalInterpreter)
           (ack l pid_var)
     HdbCLI{..} -> do
+        setBacktraceMechanismState IPEBacktrace (not disableIpeBacktraces)
         l <- mainLogger hdbOpts.verbosity stdout
         stdinStream <- case debuggeeStdin of
           Just fp -> UseHandle <$> System.IO.openFile fp ReadMode
@@ -91,6 +92,7 @@ main = do
         runIDM (contramap InteractiveLog l) entryPoint entryFile entryArgs extraGhcArgs
           runConf debugInteractive
     HdbProxy{port} -> do
+        setBacktraceMechanismState IPEBacktrace True
         l <- mainLogger hdbOpts.verbosity stdout
         runInTerminalHdbProxy (contramap RunProxyClientLog l) port
     HdbExternalInterpreter{writeFd, readFd} -> do

--- a/test/haskell/Main.hs
+++ b/test/haskell/Main.hs
@@ -44,8 +44,14 @@ main = do
   let testsForInternal = Set.toList $ internalOnlySet `Set.union` defaultTestsSet
   let testsForExternal = Set.toList $ externalOnlySet `Set.union` defaultTestsSet
 
-  default_goldens   <- mapM (mkTest "") testsForExternal
-  intinterp_goldens <- mapM (mkTest "--internal-interpreter") testsForInternal
+  -- Disable IPE backtraces in tests to ensure consistent output between
+  -- internal and external interpreter modes. When using the internal interpreter,
+  -- IPE backtraces appear in debugger output but not with the external interpreter
+  -- (since they run as separate processes). To use a single golden test file for
+  -- both modes, we disable IPE backtraces by default in tests.
+  let baseFlags = "--disable-ipe-backtraces"
+  default_goldens   <- mapM (mkTest baseFlags) testsForExternal
+  intinterp_goldens <- mapM (mkTest ("--internal-interpreter " ++ baseFlags)) testsForInternal
 
   defaultMain $
     testGroup "Tests"


### PR DESCRIPTION
The --disable-ipe-backtraces flag can be used when consistent test output between internal and external interpreter modes is required, as IPE backtraces appear in debugger output with the internal interpreter but not with the external interpreter (which runs as a separate process).

Fixes #181