### PR TITLE
Add cabal to build-tool-depends

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -208,5 +208,7 @@ test-suite haskell-debugger-test
         tasty-hunit >= 0.10.2,
         tasty-expected-failure >= 0.12.3,
         regex >= 1.1
-    build-tool-depends: haskell-debugger:hdb
+    build-tool-depends:
+          cabal-install:cabal
+        , haskell-debugger:hdb
     ghc-options: -threaded


### PR DESCRIPTION
Needed due to https://github.com/well-typed/haskell-debugger/blob/d3da6051d1f9ab08fdf4907c28f46af5e4236270/test/golden/T79/T79.hdb-test#L1

as it causes 
```
T79:                          T79.hdb-test: line 1: cabal: command not found
```
when building in contexts where `cabal-install` can not be assumed to be in PATH. 