### PR TITLE
Revert "Add cabal to build-tool-depends"

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -215,7 +215,5 @@ test-suite haskell-debugger-test
         tasty-hunit >= 0.10.2,
         tasty-expected-failure >= 0.12.3,
         regex >= 1.1
-    build-tool-depends:
-          cabal-install:cabal
-        , haskell-debugger:hdb
+    build-tool-depends: haskell-debugger:hdb
     ghc-options: -threaded


### PR DESCRIPTION
This reverts commit f7d54612dc6dba43a08205a1cc0ac59f38191c71.

Fixes #206