### PR TITLE
testsuite: Fix runInTerminal flakiness

### DIFF
--- a/hdb/Development/Debug/Adapter/Handles.hs
+++ b/hdb/Development/Debug/Adapter/Handles.hs
@@ -18,7 +18,6 @@ import GHC.IO.Handle.FD
 import GHC.IO.Handle
 import System.Process
 import Control.Exception
-import Control.Monad
 import Control.Concurrent.Async
 
 handleLogger :: Handle -> IO (LogAction IO T.Text)
@@ -117,10 +116,16 @@ withHandleBypass originalHandle interceptWriteHandle action =
 
 -- | Thread to read from the intercepted stdout pipe and forward onwards
 forwardingThread :: (T.Text -> IO ()) -> Handle -> IO ()
-forwardingThread write_action fromPipe = forever $ do
-  line <- T.hGetLine fromPipe
-  write_action line
-
+forwardingThread write_action fromPipe = loop
+  where
+    loop = do
+      eof <- hIsEOF fromPipe
+      if eof
+        then return ()
+        else do
+          line <- T.hGetLine fromPipe
+          write_action line
+          loop
 
 withPipe :: (Handle -> Handle -> IO r) -> IO r
 withPipe action = bracket createPipe closeBoth (uncurry action)

--- a/hdb/Development/Debug/Adapter/Init.hs
+++ b/hdb/Development/Debug/Adapter/Init.hs
@@ -24,7 +24,7 @@ import Data.Maybe
 import System.IO
 import GHC.IO.Encoding
 import Control.Monad.Catch
-import Control.Exception (SomeAsyncException, throwIO)
+import Control.Exception (SomeAsyncException, throwIO, IOException)
 import Control.Concurrent
 import GHC.Conc.Sync (labelThread)
 import Control.Monad
@@ -352,7 +352,10 @@ stdoutCaptureThread runInTerminal syncOut withAdaptor = do
         writeChan syncOut $ T.encodeUtf8 (line <> T.pack "\n")
 
       -- Always output to Debug Console
-      withAdaptor $ Output.stdout line
+      catch
+        (withAdaptor $ Output.stdout line)
+        (\(_ :: IOException) ->
+          throwIO (FailedToWriteToAdaptor line))
 
 -- | Like 'stdoutCaptureThread' but for stderr
 stderrCaptureThread :: Bool -> Chan BS.ByteString -> (DebugAdaptorCont () -> IO ()) -> IO ()
@@ -368,7 +371,7 @@ stderrCaptureThread runInTerminal syncErr withAdaptor = do
       -- Always output to Debug Console
       catch
         (withAdaptor $ Output.stderr line)
-        (\(_ :: SomeException) ->
+        (\(_ :: IOException) ->
           throwIO (FailedToWriteToAdaptor line))
 
 newtype FailedToWriteToAdaptor = FailedToWriteToAdaptor T.Text

--- a/hdb/Development/Debug/Adapter/Proxy.hs
+++ b/hdb/Development/Debug/Adapter/Proxy.hs
@@ -123,7 +123,7 @@ runInTerminalHdbProxy l port = do
   catch (
     runTCPClient "127.0.0.1" (show port) $ \sock -> do
       -- Forward stdin to sock
-      race_
+      concurrently_
         (catch (forever $ do
           str <- BS8.hGetLine stdin
           NBS.sendAll sock (str <> BS8.pack "\n")

--- a/test/haskell/Test/DAP/RunInTerminal.hs
+++ b/test/haskell/Test/DAP/RunInTerminal.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE CPP #-}
 module Test.DAP.RunInTerminal (runInTerminalTests) where
 
+import System.Exit
+import Control.Exception
 import Control.Monad
 import Control.Concurrent
 import DAP.Types
@@ -53,10 +55,12 @@ runInTerminal1 flags = do
       <- P.createProcess (P.shell $ "hdb server " ++ flags ++ " --port " ++ show testPort)
           {P.cwd = Just test_dir, P.std_out = P.CreatePipe, P.std_in = P.CreatePipe}
 
+    serverOutputRef <- newIORef []
+
     -- Fork thread to print out output of server process
     -- This is surprisingly needed, otherwise the server process
     -- will be broken, perhaps because it blocks trying to write to stdout/stderr if the buffer is full?
-    forkIO $ do
+    forkIO $ flip catch (\(e :: IOException) -> print ("server process forwarding", e)) $ do
       hSetBuffering hout LineBuffering
       let loop = do
             eof <- hIsEOF hout
@@ -64,14 +68,18 @@ runInTerminal1 flags = do
               then return ()
               else do
                 _l <- hGetLine hout
-                -- UNCOMMENT ME TO DEBUG
-                -- putStrLn ("[server] " ++ _l)
+                modifyIORef' serverOutputRef (_l :)
                 loop
       loop
 
+    let flushServerOutput = do
+          putStrLn "\n--- SERVER OUTPUT ---"
+          readIORef serverOutputRef >>= mapM_ putStrLn . reverse
+          putStrLn "---------------------\n"
+
     retryVar <- newIORef True
     -- Connect to the DAP server
-    withNewClient testPort retryVar $ \handle -> do
+    flip onException flushServerOutput $ withNewClient testPort retryVar $ \handle -> do
       -- As soon as we get a connection, stop retrying
       writeIORef retryVar False
 
@@ -213,9 +221,9 @@ runInTerminal1 flags = do
       -- The contents of the rit_output should contain "hello" plus printing of what we wrote
       out <- LBS.hGetContents rit_out
       let out_str = LB8.unpack out
-      assertBool ("Expected output to contain 'hello', got: " ++ out_str)
+      assertBool ("Expected output to contain 'hello', got: " ++ show out_str)
                  ("hello" `isInfixOf` out_str)
-      assertBool ("Expected output to contain '" ++ secret_in ++ "' , got: " ++ out_str)
+      assertBool ("Expected output to contain '" ++ secret_in ++ "' , got: " ++ show out_str)
                  (secret_in `isInfixOf` out_str)
 
       -- Send disconnect


### PR DESCRIPTION
Most changes are to improve the debuggability of the flaky error.

The main fix is using `concurrently_` instead of `race_`. (race_ meant one of the threads would get killed when the other returned; and note that they did always return rather than abort because both threads were wrapped in catch).
We want `concurrently_` to wait for both of them to exit naturally due to the connection being dropped.