### PR TITLE
[fix #218] Allow imports at REPL

### DIFF
--- a/haskell-debugger/GHC/Debugger.hs
+++ b/haskell-debugger/GHC/Debugger.hs
@@ -31,7 +31,7 @@ execute = \case
   GetScopes threadId frameIx -> GotScopes <$> getScopes threadId frameIx
   GetVariables threadId frameIx varRef -> GotVariables <$> getVariables threadId frameIx varRef
   GetExceptionInfo threadId -> GotExceptionInfo <$> getExceptionInfo threadId
-  DoEval exp_s -> DidEval <$> doEval exp_s
+  DoEval exp_s -> DidEval <$> doEvalCommand exp_s
   DoContinue -> DidContinue <$> doContinue
   DoSingleStep -> DidStep <$> doSingleStep
   DoStepOut -> DidStep <$> doStepOut

--- a/haskell-debugger/GHC/Debugger/Run.hs
+++ b/haskell-debugger/GHC/Debugger/Run.hs
@@ -22,6 +22,7 @@ import System.FilePath
 import System.Directory
 
 import GHC
+import GHC.Plugins (SourceError)
 import GHC.Builtin.Names (gHC_INTERNAL_GHCI_HELPERS)
 import GHC.Unit.Types
 import GHC.Data.FastString
@@ -29,6 +30,7 @@ import GHC.Driver.DynFlags as GHC
 import GHC.Driver.Main (hscParseStmtWithLocation)
 import GHC.Driver.Monad as GHC
 import GHC.Driver.Env as GHC
+import qualified GHC.Driver.Config.Parser as GHC
 import GHC.Runtime.Debugger.Breakpoints as GHC
 import qualified GHC.Unit.Module.ModSummary as GHC
 import GHC.Types.Name.Occurrence (mkVarOccFS)
@@ -165,6 +167,26 @@ doLocalStep = do
       ticks <- fromMaybe (error "doLocalStep:getTicks") <$> makeModuleLineMap md
       let current_toplevel_decl = enclosingTickSpan ticks loc
       GHC.resumeExec (LocalStep (RealSrcSpan current_toplevel_decl mempty)) Nothing >>= handleExecResult
+
+-- | Generalized `doEval` that also handles `imports`
+doEvalCommand :: String -> Debugger EvalResult
+doEvalCommand expr = do
+  dflags <- GHC.getInteractiveDynFlags
+  let pflags = GHC.initParserOpts dflags
+  if GHC.isStmt pflags expr
+    then doEval expr
+    else addImport expr
+
+-- | Parses input as an import declaration and applies it to the interactive context.
+addImport :: String -> Debugger EvalResult
+addImport s = handleError $ do
+  cxt <- GHC.getContext
+  idecl <- parseImportDecl s
+  GHC.setContext $ IIDecl idecl : cxt
+  pure $ EvalCompleted "" "" Nothing NoVariables
+  where
+    handleError m = m `catch` \ (e::SourceError) -> do
+      pure $ EvalAbortedWith $ displayException e
 
 -- | Evaluate expression. Includes context of breakpoint if stopped at one (the current interactive context).
 doEval :: String -> Debugger EvalResult

--- a/test/golden/T218/Main.hs
+++ b/test/golden/T218/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = return ()

--- a/test/golden/T218/T218.hdb-stdin
+++ b/test/golden/T218/T218.hdb-stdin
@@ -1,0 +1,6 @@
+print isLetter
+print import Data.Char
+print isLetter
+print isLetter 'a'
+print isLetter '1'
+print import Does.Not.Exist

--- a/test/golden/T218/T218.hdb-stdout
+++ b/test/golden/T218/T218.hdb-stdout
@@ -1,0 +1,12 @@
+[1 of 3] Compiling GHC.Debugger.View.Class ( in-memory:GHC.Debugger.View.Class, interpreted )[haskell-debugger-view-in-memory]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/Main.hs, interpreted )[main]
+(hdb) Aborted: <interactive>:1:1: error: [GHC-88464]
+    Variable not in scope: isLetter
+(hdb) 
+(hdb) <fn> :: Char -> Bool
+(hdb) True
+(hdb) False
+(hdb) Aborted: <interactive>:1:1: error: [GHC-87110]
+    Could not find module `Does.Not.Exist'.
+    Use -v to see a list of the files searched for.
+(hdb) Exiting...

--- a/test/golden/T218/T218.hdb-test
+++ b/test/golden/T218/T218.hdb-test
@@ -1,0 +1,1 @@
+$HDB Main.hs -v 0 < T218.hdb-stdin


### PR DESCRIPTION
Evaluate command now handles `import Some.Module` declarations.

```
(hdb) print isLetter
Aborted: <interactive>:1:1: error: [GHC-88464]
    Variable not in scope: isLetter
(hdb) print import Data.Char

(hdb) print isLetter
<fn> :: Char -> Bool
(hdb) print isLetter 'a'
True
(hdb) print import Does.Not.Exist
Aborted: <interactive>:1:1: error: [GHC-87110]
    Could not find module `Does.Not.Exist'.
    Use -v to see a list of the files searched for.
```