### PR TITLE
Run test suite in parallel by default

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -233,3 +233,6 @@ test-suite haskell-debugger-test
         regex >= 1.1
     build-tool-depends: haskell-debugger:hdb
     ghc-options: -threaded
+    -- TODO: Investigate apparent race condition on windows
+    if !os(windows)
+        ghc-options: -rtsopts "-with-rtsopts=-N"


### PR DESCRIPTION
On my machine, the test suite goes from ~110s to ~18s.
Note the output is slightly garbled due to the stray `"HandlingTerminateServer"` messages.

Sequential run
```
...
   exceptions:                                      OK (0.64s)
  Unit tests
    DAP.RunInTerminal
      runInTerminal: proxy forwards stdin correctly
        (default):                                   "HandlingTerminateServer"
        (default):                                   OK (0.56s)
        (--internal-interpreter):                    OK (0.46s)
    DAP.Scopes
      Locals is cheap, Module/Globals are expensive: "HandlingTerminateServer"
      Locals is cheap, Module/Globals are expensive: OK (0.49s)
    DAP.LogMessage
      breakpoint with logMessage
        fixed message:                               "HandlingTerminateServer"
        fixed message:                               OK (0.46s)
        interpolation:                               "HandlingTerminateServer"
        interpolation:                               OK (0.46s)
        escape in message:                           "HandlingTerminateServer"
        escape in message:                           OK (0.46s)
        escape in antiquote:                         "HandlingTerminateServer"
        escape in antiquote:                         OK (0.46s)
        log only when condition:                     OK (0.49s)
```

Parallel run
```
Running 1 test suites...
Test suite haskell-debugger-test: RUNNING...
Tests
  Golden tests
    T130:                                            "HandlingTerminateServer"
"HandlingTerminateServer"
"HandlingTerminateServer"
"HandlingTerminateServer"
"HandlingTerminateServer"
"HandlingTerminateServer"
"HandlingTerminateServer"
    T130:                                            OK (14.97s)
    T130b:                                           OK (15.59s)
...
```