### PR TITLE
[Fix #217] Normalise type for function check

### DIFF
--- a/haskell-debugger/GHC/Debugger/Run.hs
+++ b/haskell-debugger/GHC/Debugger/Run.hs
@@ -331,7 +331,9 @@ inspectName n = do
     Nothing -> do
       liftIO . putStrLn =<< display (text "Failed to lookup name: " <+> ppr n)
       pure Nothing
-    Just tt -> Just <$> tyThingToVarInfo tt
+    Just tt -> Just <$> do
+      fam_envs <- getFamInstEnvs'
+      tyThingToVarInfo fam_envs tt
 
 getRemoteThreadIdFromContext :: Debugger RemoteThreadId
 getRemoteThreadIdFromContext = do

--- a/haskell-debugger/GHC/Debugger/Stopped.hs
+++ b/haskell-debugger/GHC/Debugger/Stopped.hs
@@ -265,6 +265,7 @@ getVariables threadId frameIx vk = do
   frames <- getStacktrace threadId
   let frame = frames !! frameIx
   hsc_env <- getSession
+  fam_envs <- getFamInstEnvs'
   case vk of
     -- Only `seq` the variable when inspecting a specific one (`SpecificVariable`)
     -- (VARR)(b,c)
@@ -282,7 +283,7 @@ getVariables threadId frameIx vk = do
 
           term' <- forceTerm term
 
-          vi <- termToVarInfo key term'
+          vi <- termToVarInfo fam_envs key term'
 
           return (ForcedVariable vi)
 
@@ -293,14 +294,14 @@ getVariables threadId frameIx vk = do
           -- Meaning the @SpecificVariable@ request means to inspect the structure.
           -- Return ONLY the fields
 
-          termVarFields key term >>= \case
+          termVarFields fam_envs key term >>= \case
             VarFields vfs -> pure (VariableFields vfs)
 
     -- (VARR)(a) from here onwards
 
     LocalVariables -> fmap VariableFields $ do
       -- bindLocalsAtBreakpoint hsc_env (GHC.resumeApStack r) (GHC.resumeSpan r) (GHC.resumeBreakpointId r)
-      mapM tyThingToVarInfo =<< GHC.getBindings
+      mapM (tyThingToVarInfo fam_envs) =<< GHC.getBindings
 
     ModuleVariables
       | frameIx < length frames
@@ -311,7 +312,7 @@ getVariables threadId frameIx vk = do
         things <- typeEnvElts <$> getTopEnv curr_modl
         mapM (\tt -> do
           nameStr <- display (getName tt)
-          vi <- tyThingToVarInfo tt
+          vi <- tyThingToVarInfo fam_envs tt
           return vi{varName = nameStr}) things
 
     GlobalVariables
@@ -333,7 +334,7 @@ getVariables threadId frameIx vk = do
                 , varRef = NoVariables
                 }
             Just tt -> do
-              vi <- tyThingToVarInfo tt
+              vi <- tyThingToVarInfo fam_envs tt
               return vi{varName = nameStr}
           ) names
 

--- a/haskell-debugger/GHC/Debugger/Stopped/Variables.hs
+++ b/haskell-debugger/GHC/Debugger/Stopped/Variables.hs
@@ -5,6 +5,7 @@
 module GHC.Debugger.Stopped.Variables where
 
 import Control.Monad.Reader
+import qualified Colog.Core as Logger
 
 import GHC
 import GHC.Types.FieldLabel
@@ -12,7 +13,10 @@ import GHC.Types.Id.Info
 import GHC.Types.Var
 import GHC.Runtime.Eval
 import GHC.Core.DataCon
+import GHC.Core.FamInstEnv (topNormaliseType_maybe, emptyFamInstEnvs)
 import GHC.Core.TyCo.Rep
+import GHC.Core.Reduction (Reduction(..))
+import GHC.Tc.Instance.Family (tcGetFamInstEnvs, FamInstEnvs)
 import qualified GHC.Runtime.Debugger     as GHCD
 import qualified GHC.Runtime.Heap.Inspect as GHCI
 
@@ -25,8 +29,8 @@ import GHC.Debugger.Utils
 
 -- | 'TyThing' to 'VarInfo'. The 'Bool' argument indicates whether to force the
 -- value of the thing (as in @True = :force@, @False = :print@)
-tyThingToVarInfo :: TyThing -> Debugger VarInfo
-tyThingToVarInfo t = case t of
+tyThingToVarInfo :: FamInstEnvs -> TyThing -> Debugger VarInfo
+tyThingToVarInfo fam_envs t = case t of
   AConLike c -> VarInfo <$> display c <*> display t <*> display t <*> pure False <*> pure NoVariables
   ATyCon c   -> VarInfo <$> display c <*> display t <*> display t <*> pure False <*> pure NoVariables
   ACoAxiom c -> VarInfo <$> display c <*> display t <*> display t <*> pure False <*> pure NoVariables
@@ -40,14 +44,14 @@ tyThingToVarInfo t = case t of
   AnId i -> do
     let key = FromId i
     term <- obtainTerm key
-    termToVarInfo key term
+    termToVarInfo fam_envs key term
 
 -- | Construct the VarInfos of the fields ('VarFields') of the given 'TermKey'/'Term'
 --
 -- This is used to come up with terms for the fields of an already `seq`ed
 -- variable which was expanded.
-termVarFields :: TermKey -> Term -> Debugger VarFields
-termVarFields top_key top_term = do
+termVarFields :: FamInstEnvs -> TermKey -> Term -> Debugger VarFields
+termVarFields fam_envs top_key top_term = do
 
   vcVarFields <- debugFieldsTerm top_term
 
@@ -56,7 +60,7 @@ termVarFields top_key top_term = do
     Just fls -> do
 
       let keys = map (\(f_name, f_term) -> FromCustomTerm top_key f_name f_term) fls
-      VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo k) keys
+      VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo fam_envs k) keys
 
     -- The general case
     _ -> case top_term of
@@ -67,61 +71,60 @@ termVarFields top_key top_term = do
           -- Use indexed fields
           [] -> do
             let keys = zipWith (\ix _ -> FromPath top_key (PositionalIndex ix)) [1..] (dataConRepArgTys dc)
-            VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo k) keys
+            VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo fam_envs k) keys
           -- Is a record data con,
           -- Use field labels
           dataConFields -> do
             let mkPath ix Nothing = FromPath top_key (PositionalIndex ix)
                 mkPath ix (Just fld) = FromPath top_key (LabeledField ix (flSelector fld))
                 keys = zipWith mkPath [1..] ((Nothing <$ dataConOtherTheta dc) ++ (map Just dataConFields))
-            VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo k) keys
+            VarFields <$> mapM (\k -> obtainTerm k >>= termToVarInfo fam_envs k) keys
       NewtypeWrap{dc=Right dc, wrapped_term=_{- don't use directly! go through @obtainTerm@ -}} -> do
         case dataConFieldLabels dc of
           [] -> do
             let key = FromPath top_key (PositionalIndex 1)
-            wvi <- obtainTerm key >>= termToVarInfo key
+            wvi <- obtainTerm key >>= termToVarInfo fam_envs key
             return (VarFields [wvi])
           [fld] -> do
             let key = FromPath top_key (LabeledField 1 (flSelector fld))
-            wvi <- obtainTerm key >>= termToVarInfo key
+            wvi <- obtainTerm key >>= termToVarInfo fam_envs key
             return (VarFields [wvi])
           _ -> error "unexpected number of Newtype fields: larger than 1"
       RefWrap{wrapped_term=_{- don't use directly! go through @obtainTerm@ -}} -> do
         let key = FromPath top_key (PositionalIndex 1)
-        wvi <- obtainTerm key >>= termToVarInfo key
+        wvi <- obtainTerm key >>= termToVarInfo fam_envs key
         return (VarFields [wvi])
       _ -> return (VarFields [])
 
 
 -- | Construct a 'VarInfo' from the given 'Name' of the variable and the 'Term' it binds
-termToVarInfo :: TermKey -> Term -> Debugger VarInfo
-termToVarInfo key term0 = do
+--   The @FamInstEnvs@ is used to look through newtypes and type families when checking if suspensions are of function type.
+termToVarInfo :: FamInstEnvs -> TermKey -> Term -> Debugger VarInfo
+termToVarInfo fam_envs key term0 = do
   -- Make a VarInfo for a term
   let
     ty = GHCI.termType term0
 
-    -- Check for function types explicitly since they seem to always match Suspension
-    -- but should not be shown as thunks in the UI.
-    checkFn (FunTy _ _ _ _) = True
-    checkFn (ForAllTy _ t) = checkFn t
-    checkFn _ = False
-    isFn = checkFn ty
-
   varName <- display key
   varType <- display ty
   case term0 of
+    t | Suspension{} <- unwrapNewtype t, isFunctionType ty -> do
+      return VarInfo
+        { varName
+        , varType
+        , varValue = "<fn> :: " ++ varType
+        , varRef = NoVariables
+        , isThunk = False
+        }
+
     -- The simple case: The term is a a thunk...
     Suspension{} -> do
       return VarInfo
         { varName
         , varType
-        , varValue = if isFn
-            then "<fn> :: " ++ varType
-            else "_"
-        , varRef = if isFn
-            then NoVariables
-            else SpecificVariable key -- allows forcing the thunk
-        , isThunk = not isFn
+        , varValue = "_"
+        , varRef = SpecificVariable key -- allows forcing the thunk
+        , isThunk = True
         }
 
     -- Otherwise, try to apply and decode a custom 'DebugView', or default to
@@ -182,7 +185,44 @@ termToVarInfo key term0 = do
       Prim{}         -> False
       NewtypeWrap{}  -> True
       RefWrap{}      -> True
-      Term{subTerms} -> not $ null subTerms
+      Term{subTerms} -> not $ null $ subTerms
+    -- Check for function types explicitly since they seem to always match Suspension
+    -- but should not be shown as thunks in the UI.
+    isFunctionType = \case
+      (FunTy _ _ _ _) -> True
+      (ForAllTy _ t)  -> isFunctionType t
+      (topNormaliseType_maybe fam_envs -> Just Reduction{..})
+        -> isFunctionType reductionReducedType
+      _ -> False
+    -- FIXME: couldn't find test case where this is needed.
+    unwrapNewtype (NewtypeWrap {wrapped_term}) = unwrapNewtype wrapped_term
+    unwrapNewtype x = x
+
+-- | Thin wrapper around @tcGetFamInstEnvs@, using @runTcInteractive@
+getFamInstEnvs' :: Debugger FamInstEnvs
+getFamInstEnvs' = do
+  hsc_env <- getSession
+  (err_msgs, res) <- liftIO $ runTcInteractive hsc_env $ tcGetFamInstEnvs
+  case res of
+    Just fam_envs -> pure fam_envs
+    Nothing -> do
+      logSDoc Logger.Debug
+        $ text "Couldn't lookup FamInstEnvs to normalise type for VarInfo,"
+        <+> text "using empty ones."
+        $$  ppr err_msgs
+      return emptyFamInstEnvs
+
+pprTerm :: Term -> SDoc
+pprTerm t = case t of
+  Term{dc,subTerms} -> annotate "T:" $
+    either text ppr dc <+> ppr (map pprTerm subTerms)
+  Prim{valRaw} -> annotate "P:" $ ppr valRaw
+  Suspension{bound_to,ctype} -> annotate "S:" $ ppr bound_to <+> text (show ctype)
+  NewtypeWrap{dc,wrapped_term} ->
+    annotate "N:" $ either text ppr dc <+> pprTerm wrapped_term
+  RefWrap{wrapped_term} -> annotate "R:" $ pprTerm wrapped_term
+  where
+    annotate tag d = parens $ text tag <+> ppr (ty t) <+> text "∋" <+> d
 
 -- | Forces a term to WHNF
 --
@@ -191,4 +231,3 @@ forceTerm :: Term -> Debugger Term
 forceTerm term = do
   hsc_env <- getSession
   liftIO $ seqTerm hsc_env term
-

--- a/test/golden/T164/T164.ghc-914.hdb-stdout
+++ b/test/golden/T164/T164.ghc-914.hdb-stdout
@@ -2,9 +2,7 @@
 [2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/Main.hs, interpreted )[main]
 (hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 5], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/Main.hs", startLine = 42, endLine = 42, startCol = 3, endCol = 70}}
 (hdb) Stopped at breakpoint
-(hdb) _result : IO () = _
-*** Ignoring breakpoint [<TEMPORARY-DIRECTORY>/Main.hs:42:3-69]
-  _result : IO () = _
+(hdb) _result : IO () = <fn> :: IO ()
 existentialFoo : Foo = Foo
   _1 : r0 = _
   _2 : [Char] = "value"

--- a/test/golden/T217/Main.hs
+++ b/test/golden/T217/Main.hs
@@ -1,0 +1,20 @@
+newtype D a = D {unD :: D a -> a}
+newtype B = B (Either String Bool)
+  deriving Show
+{-# OPAQUE f #-}
+f :: B -> Either B B
+f b = Left b
+
+main = do
+  let doit = const (pure () :: IO ())
+  let y = D (const $ 'y')
+  let x :: (a ~ IO ()) => a
+      x = print ()
+  -- to preserve newtype constructor `B` in reconstructed Term we must not force `ix`
+  -- until after the breakpoint.
+  ix <- pure $ B (Left "A")
+  putStrLn "helio"
+  doit ()
+  print $ unD y y
+  x
+  print (f ix)

--- a/test/golden/T217/T217.ghc-914.hdb-stdout
+++ b/test/golden/T217/T217.ghc-914.hdb-stdout
@@ -1,0 +1,12 @@
+[1 of 3] Compiling GHC.Debugger.View.Class ( in-memory:GHC.Debugger.View.Class, interpreted )[haskell-debugger-view-in-memory]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/Main.hs, interpreted )[main]
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 13], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/Main.hs", startLine = 17, endLine = 17, startCol = 3, endCol = 10}}
+(hdb) helio
+Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+x : forall a. (a ~ IO ()) => a = <fn> :: forall a. (a ~ IO ()) => a
+y : D Char -> Char = <fn> :: D Char -> Char
+doit : forall {b}. b -> IO () = <fn> :: forall {b}. b -> IO ()
+ix : B = _
+  ix : B = B (Left _)
+(hdb) Exiting...

--- a/test/golden/T217/T217.hdb-stdin
+++ b/test/golden/T217/T217.hdb-stdin
@@ -1,0 +1,3 @@
+break Main.hs 17
+run
+variables

--- a/test/golden/T217/T217.hdb-test
+++ b/test/golden/T217/T217.hdb-test
@@ -1,0 +1,1 @@
+$HDB Main.hs -v 0 < T217.hdb-stdin


### PR DESCRIPTION
GHC has a handy `topNormaliseType_maybe` to normalise away newtypes and type family applications (and get at the representation type), which seems to do the job.

TODOs:
- ~~[ ] Find testcase where we need to go through NewtypeWrap to get at the Suspension (or remove code).~~
   - NewtypeWrap only generated on top of Term atm.
- [x] Add a test with equality constraints: `let foo : forall a. a ~ IO () => a = print ()`
- [x] Refactor call to `getInstFamEnvs'` to only do it once at the top?
- [x] Squash eventual wip commits
- [x] Check Term generation for insight in the type variable case
  - The rtti type of a term can be a type variable even if the term is a non-polymorphic value.
- [x] add test that newtypes of datatypes are displayed as expandable.
- [x] Implement plan at https://github.com/well-typed/haskell-debugger/pull/240#discussion_r3001328904