### PR TITLE
Add test for #239

### DIFF
--- a/test/golden/T239/Main.hs
+++ b/test/golden/T239/Main.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -O -fno-unoptimized-core-for-interpreter #-}
+{-# LANGUAGE BangPatterns #-}
+
+module Main where
+
+data Packed = Packed -- Unpacking only happens with optimizations, hence the -O.
+  { packedLeft :: {-# UNPACK #-} !Char
+  , packedRight :: {-# UNPACK #-} !Char
+  }
+  deriving Show
+
+data Container = Container
+  { containerBefore :: Int
+  , containerPacked :: {-# UNPACK #-} !Packed
+  , containerPacked2 :: {-# UNPACK #-} !Packed
+  , containerAfter :: Int
+  }
+  deriving Show
+
+mkContainer :: Container
+mkContainer = Container 10 (Packed 'a' 'b') (Packed 'c' 'd') 40
+{-# OPAQUE mkContainer #-}
+
+main :: IO ()
+main = do
+  let !container = mkContainer
+  const (pure ()) container
+  print container

--- a/test/golden/T239/T239.fails-239.ghc-914.hdb-stdout
+++ b/test/golden/T239/T239.fails-239.ghc-914.hdb-stdout
@@ -1,0 +1,11 @@
+[1 of 3] Compiling GHC.Debugger.View.Class ( in-memory:GHC.Debugger.View.Class, interpreted )[haskell-debugger-view-in-memory]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/Main.hs, interpreted )[main]
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 2], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/Main.hs", startLine = 27, endLine = 27, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+container : Container = Container
+  containerBefore : Int = _
+  containerPacked : Packed = Packed
+  containerPacked2 : Packed = Packed
+  containerAfter : Int = _
+(hdb) (hdb) Exiting...

--- a/test/golden/T239/T239.fails-239.hdb-test
+++ b/test/golden/T239/T239.fails-239.hdb-test
@@ -1,0 +1,1 @@
+$HDB Main.hs -v 0 < T239.hdb-stdin

--- a/test/golden/T239/T239.hdb-stdin
+++ b/test/golden/T239/T239.hdb-stdin
@@ -1,0 +1,4 @@
+break Main.hs 27
+run
+variables
+exit

--- a/test/haskell/Main.hs
+++ b/test/haskell/Main.hs
@@ -19,9 +19,7 @@ import System.Environment
 import Control.Exception
 
 import Test.Tasty
-#ifdef mingw32_HOST_OS
 import Test.Tasty.ExpectedFailure
-#endif
 import Test.Tasty.Golden as G
 import Test.Tasty.Golden.Advanced as G
 
@@ -40,6 +38,8 @@ import Test.Integration.Conditional (conditionalTests)
 import Test.Integration.Evaluate (evaluateTests)
 import Test.Integration.StackTrace (stackTraceTests)
 import Test.Utils
+import qualified Data.Char as C
+import qualified Data.Text as T
 
 main :: IO ()
 main = do
@@ -144,10 +144,11 @@ goldenVsStringComparing
   -- ^ action that returns a string
   -> TestTree
   -- ^ the test verifies that the returned string is the same as the golden file contents
-goldenVsStringComparing name ref act = do
+goldenVsStringComparing name ref act =
 
-  -- Normalise the output. The test file should already be saved normalised.
-  goldenTest name (LT.decodeUtf8 <$> readFileStrict ref) normalisingAct cmpNormalising upd
+  maybeExpectFail $
+    -- Normalise the output. The test file should already be saved normalised.
+    goldenTest name (LT.decodeUtf8 <$> readFileStrict ref) normalisingAct cmpNormalising upd
 
   where
   upd = createDirectoriesAndWriteFile ref . LT.encodeUtf8
@@ -203,6 +204,13 @@ goldenVsStringComparing name ref act = do
 
   forceLbs :: LBS.ByteString -> ()
   forceLbs = LBS.foldr seq ()
+
+  -- if testname contains `.fails-234` we expect a failure described by ticket #234
+  maybeExpectFail = case T.breakOn ".fails-" (T.pack name) of
+    (_, rest)
+      | let num = T.takeWhile C.isDigit (T.drop (T.length ".fails-") rest)
+      , not (T.null num) -> expectFailBecause ("#" ++ T.unpack num)
+      | otherwise -> id
 
 --------------------------------------------------------------------------------
 -- Normalisation


### PR DESCRIPTION
Tests UNPACKed fields with record labels are not broken

This is not yet a fix for #239, just putting the test with the right output on the map.