### PR TITLE
test: Add newtype debug view tests for #234

### DIFF
--- a/test/golden/T234/T234.cabal
+++ b/test/golden/T234/T234.cabal
@@ -1,0 +1,17 @@
+cabal-version:   3.14
+name:            T234
+version:         0.1.0.0
+license:         NONE
+author:          Rodrigo Mesquita
+maintainer:      rodrigo.m.mesquita@gmail.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  Lib
+    build-depends:    base, haskell-debugger-view
+    hs-source-dirs:   lib
+    default-language: Haskell2010

--- a/test/golden/T234/T234.ghc-914.hdb-stdout
+++ b/test/golden/T234/T234.ghc-914.hdb-stdout
@@ -1,0 +1,7 @@
+[1 of 1] Compiling Lib              ( <TEMPORARY-DIRECTORY>/lib/Lib.hs, interpreted )[T234-0.1.0.0-inplace]
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Lib 0], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/lib/Lib.hs", startLine = 16, endLine = 16, startCol = 3, endCol = 14}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : ColonList = _
+  value : ColonList = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T234/T234.hdb-stdin
+++ b/test/golden/T234/T234.hdb-stdin
@@ -1,0 +1,3 @@
+break lib/Lib.hs 16
+run
+variables

--- a/test/golden/T234/T234.hdb-test
+++ b/test/golden/T234/T234.hdb-test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$HDB -v0 --entry-point mainish lib/Lib.hs 2>&1 < T234.hdb-stdin

--- a/test/golden/T234/lib/Lib.hs
+++ b/test/golden/T234/lib/Lib.hs
@@ -1,0 +1,20 @@
+module Lib (mainish) where
+
+import Data.List (intercalate)
+import GHC.Debugger.View.Class
+
+newtype ColonList = ColonList [String]
+  deriving Show
+
+instance DebugView ColonList where
+  debugValue (ColonList xs) = simpleValue (intercalate ":" xs) False
+  debugFields _ = pure (VarFields [])
+
+mainish :: IO ()
+mainish = do
+  let value = mkValue
+  print value
+
+mkValue :: ColonList
+mkValue = ColonList ["alpha", "beta", "gamma"]
+{-# OPAQUE mkValue #-}

--- a/test/golden/T234b/T234b.cabal
+++ b/test/golden/T234b/T234b.cabal
@@ -1,0 +1,17 @@
+cabal-version:   3.14
+name:            T234b
+version:         0.1.0.0
+license:         NONE
+author:          Rodrigo Mesquita
+maintainer:      rodrigo.m.mesquita@gmail.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  Lib
+    build-depends:    base, haskell-debugger-view
+    hs-source-dirs:   lib
+    default-language: Haskell2010

--- a/test/golden/T234b/T234b.ghc-914.hdb-stdout
+++ b/test/golden/T234b/T234b.ghc-914.hdb-stdout
@@ -1,0 +1,7 @@
+[1 of 1] Compiling Lib              ( <TEMPORARY-DIRECTORY>/lib/Lib.hs, interpreted )[T234b-0.1.0.0-inplace]
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Lib 0], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/lib/Lib.hs", startLine = 18, endLine = 18, startCol = 3, endCol = 14}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : ColonList = _
+  value : ColonList = This is an IORef!
+(hdb) Exiting...

--- a/test/golden/T234b/T234b.hdb-stdin
+++ b/test/golden/T234b/T234b.hdb-stdin
@@ -1,0 +1,3 @@
+break lib/Lib.hs 18
+run
+variables

--- a/test/golden/T234b/T234b.hdb-test
+++ b/test/golden/T234b/T234b.hdb-test
@@ -1,0 +1,1 @@
+$HDB -v0 --entry-point mainish lib/Lib.hs 2>&1 < T234b.hdb-stdin

--- a/test/golden/T234b/lib/Lib.hs
+++ b/test/golden/T234b/lib/Lib.hs
@@ -1,0 +1,21 @@
+module Lib (mainish) where
+
+import Data.IORef (IORef, newIORef)
+import GHC.Debugger.View.Class
+
+newtype ColonList = ColonList (IORef [String])
+
+instance Show ColonList where
+  show _ = "<colon-list>"
+
+instance DebugView ColonList where
+  debugValue _ = simpleValue "This is an IORef!" False
+  debugFields _ = pure (VarFields [])
+
+mainish :: IO ()
+mainish = do
+  value <- mkValue
+  print value
+
+mkValue :: IO ColonList
+mkValue = ColonList <$> newIORef ["alpha", "beta", "gamma"]


### PR DESCRIPTION
This is a regression test for #234, where DebugView instances for newtype constructors don't work.

These duplicate T130c, but use a `newtype` instead of `data`.