### PR TITLE
test: Add test for DebugView orphan instances

### DIFF
--- a/test/golden/T237/T237.cabal
+++ b/test/golden/T237/T237.cabal
@@ -1,0 +1,24 @@
+cabal-version:   3.14
+name:            T237
+version:         0.1.0.0
+license:         NONE
+author:          Rodrigo Mesquita
+maintainer:      rodrigo.m.mesquita@gmail.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyType
+    build-depends:    base
+    hs-source-dirs:   lib
+    default-language: Haskell2010
+
+executable T237
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base, T237, haskell-debugger-view
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/test/golden/T237/T237.ghc-914.hdb-stdout
+++ b/test/golden/T237/T237.ghc-914.hdb-stdout
@@ -1,0 +1,16 @@
+[1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, interpreted )[T237-0.1.0.0-inplace-T237]
+[;1m<TEMPORARY-DIRECTORY>/app/Main.hs:8:1: [;1m[35mwarning[0m[0m[;1m: [GHC-90177] [[;1m[35m-Worphans[0m[0m[;1m][0m[0m[;1m
+    Orphan class instance: instance DebugView MyType
+    Suggested fix:
+      Move the instance declaration to the module of the class or of the type, or
+      wrap the type with a newtype and declare the instance on the new type.[0m[0m
+[;1m[34m  |[0m[0m
+[;1m[34m8 |[0m[0m [;1m[35minstance DebugView MyType where[0m[0m
+[;1m[34m  |[0m[0m[;1m[35m ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...[0m[0m
+
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 1], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/app/Main.hs", startLine = 15, endLine = 15, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : MyType = _
+  value : MyType = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T237/T237.hdb-stdin
+++ b/test/golden/T237/T237.hdb-stdin
@@ -1,0 +1,3 @@
+break app/Main.hs 15
+run
+variables

--- a/test/golden/T237/T237.hdb-test
+++ b/test/golden/T237/T237.hdb-test
@@ -1,0 +1,1 @@
+$HDB -v0 app/Main.hs 2>&1 < T237.hdb-stdin || true

--- a/test/golden/T237/app/Main.hs
+++ b/test/golden/T237/app/Main.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import Data.List (intercalate)
+
+import GHC.Debugger.View.Class
+import MyType
+
+instance DebugView MyType where
+  debugValue (MyType xs) = simpleValue (intercalate ":" xs) False
+  debugFields _ = pure (VarFields [])
+
+main :: IO ()
+main = do
+  let value = mkValue
+  const (print value) value

--- a/test/golden/T237/lib/MyType.hs
+++ b/test/golden/T237/lib/MyType.hs
@@ -1,0 +1,11 @@
+module MyType
+  ( MyType(..)
+  , mkValue
+  ) where
+
+newtype MyType = MyType [String]
+  deriving Show
+
+mkValue :: MyType
+mkValue = MyType ["alpha", "beta", "gamma"]
+{-# OPAQUE mkValue #-}


### PR DESCRIPTION
Seemingly, #237 is not about all orphan instances, but rather some
    slightly more contrived scenario that prevents us from using a
    `DebugView ModuleGraph` defined as an orphan in the debugger when
    debugging the debugger.

    This test checks that orphan instances in a normal situation work
    properly.

Complements the tests added in the fix to #237 