### PR TITLE
[Fix #257] Keep hdb server running when debug session ends

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -206,6 +206,7 @@ test-suite haskell-debugger-test
     other-modules:    Test.DAP.RunInTerminal,
                       Test.DAP.Scopes,
                       Test.DAP.LogMessage,
+                      Test.DAP.Persistent,
                       Test.DAP,
                       Test.DAP.Init,
                       Test.DAP.Messages,
@@ -213,6 +214,7 @@ test-suite haskell-debugger-test
                       Test.Utils
     build-depends:
         base >=4.14,
+        async,
         haskell-debugger,
         bytestring, text,
         containers,

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -427,9 +427,14 @@ runDebugger l rootDir compDir libdir units ghcInvocation' extraGhcArgs mainFp co
                 then Nothing
                 else Just hdv_uid)
 
-    fwd_thr <- liftIO $ async (void externalInterpFwdThread)
-    liftIO $ link fwd_thr
-    mainGhcThread
+    withUnliftGhc $ \ unlift -> do
+      withAsync (void externalInterpFwdThread) $ \ fwd_thr -> do
+        liftIO $ link fwd_thr
+        unlift mainGhcThread
+
+-- | WARNING: callback is not to be used from other threads.
+withUnliftGhc :: ((Ghc b -> IO b) -> IO a) -> Ghc a
+withUnliftGhc k = reifyGhc $ \ s -> k (flip reflectGhc s)
 
 {-
 Note [Custom external interpreter]

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -207,7 +207,11 @@ runDebugger l rootDir compDir libdir units ghcInvocation' extraGhcArgs mainFp co
   GHC.runGhc (Just libdir) $ do
 #ifdef MIN_VERSION_unix
     -- Workaround #4162
+    -- FIXME: setup reasonable handlers to run cleanupSession for every debugger thread, because runGhc's `withSignalHandlers` is not it.
     _ <- liftIO $ installHandler sigINT Default Nothing
+    _ <- liftIO $ installHandler sigQUIT Default Nothing
+    _ <- liftIO $ installHandler sigTERM Default Nothing
+    _ <- liftIO $ installHandler sigHUP Default Nothing
 #endif
     dflags0 <- GHC.getSessionDynFlags
     let dflags1 = dflags0

--- a/hdb/Development/Debug/Adapter/Exit.hs
+++ b/hdb/Development/Debug/Adapter/Exit.hs
@@ -27,6 +27,7 @@ import Data.Function
 import System.IO
 import Control.Monad
 import Control.Monad.IO.Class
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Exception
 import Control.Exception.Context
 import qualified Data.Text as T
@@ -45,7 +46,7 @@ commandTerminate = do
   -- DidTerminate <- sendInterleaved TerminateProcess sendTerminateResponse
   destroyDebugSession
   sendTerminateResponse
-  exitCleanly Nothing
+  terminateSessionCleanly Nothing
 
 -- | Command disconnect (1b)
 --
@@ -54,7 +55,7 @@ commandDisconnect :: DebugAdaptor ()
 commandDisconnect = do
   destroyDebugSession
   sendDisconnectResponse
-  exitCleanly Nothing
+  terminateSessionCleanly Nothing
 
 --- Exit Cleanly ---------------------------------------------------------------
 
@@ -83,25 +84,23 @@ exitCleanupWithMsg final_handle msg = do
   exitWithMsg msg
 
 -- | Logs the error to the debug console and sends a terminate event
-exitWithMsg :: String -> DebugAdaptor a
+exitWithMsg :: String -> DebugAdaptor ()
 exitWithMsg msg = do
   Output.important (T.pack msg)
-  exitCleanly (Just msg)
+  terminateSessionCleanly (Just msg)
 
-exitCleanly :: Maybe String -> DebugAdaptor a
-exitCleanly mm = do
-
+terminateSessionCleanly :: Maybe String -> DebugAdaptor ()
+terminateSessionCleanly mm = do
+  -- throws error if no session found.
+  destroyDebugSession `catchError` \ e -> liftIO $ hPutStrLn stdout ("terminateSessionCleanly: ignoring missing session: " ++ show e)
   sendTerminatedEvent (TerminatedEvent False)
 
-  -- We exit here to guarantee the process is killed when
-  -- terminated. Important! We want a new server process per
-  -- session, which means at the end we must kill the server.
   liftIO $ do
     case mm of
-      Nothing -> throwIO TerminateServer
+      Nothing -> return ()
       Just em -> do
         hPutStrLn stderr em
-        throwIO TerminateServer
+        return ()
 
 --- Utils ----------------------------------------------------------------------
 
@@ -111,4 +110,3 @@ displayExceptionWithContext ex = do
   case displayExceptionContext (someExceptionContext ex) of
     "" -> displayException ex
     cx -> displayException ex ++ "\n\n" ++ cx
-

--- a/hdb/Development/Debug/Adapter/Init.hs
+++ b/hdb/Development/Debug/Adapter/Init.hs
@@ -23,6 +23,7 @@ import qualified Data.Text.Encoding as T
 import qualified System.Process as P
 import Control.Monad.Except
 import Control.Monad.Trans
+import Data.Bifunctor
 import Data.Function
 import Data.Functor
 import Data.Maybe
@@ -37,6 +38,7 @@ import GHC.Generics
 import System.Directory
 import System.FilePath
 import Data.Functor.Contravariant
+import Network.Socket (PortNumber)
 
 import Development.Debug.Adapter
 import Development.Debug.Adapter.Exit
@@ -53,6 +55,7 @@ import GHC.Debugger.Interface.Messages hiding (Command, Response)
 import DAP
 import Development.Debug.Adapter.Handles
 import Development.Debug.Session.Setup
+import Development.Debug.Adapter.Proxy
 
 --------------------------------------------------------------------------------
 -- * Client
@@ -84,6 +87,7 @@ data LaunchArgs
 data DAPLog
   = DAPSessionSetupLog (WithSeverity SessionSetupLog)
   | DAPDebuggerLog Debugger.DebuggerLog
+  | RunProxyServerLog (WithSeverity T.Text)
 
 --------------------------------------------------------------------------------
 -- * Launch Debugger
@@ -96,9 +100,9 @@ newtype InitFailed = InitFailed String deriving Show
 -- | Initialize debugger
 --
 -- Returns @()@ if successful, throws @InitFailed@ otherwise
-initDebugger :: LogAction IO DAPLog -> Bool -> Bool
-             -> LaunchArgs -> ExceptT InitFailed DebugAdaptor ()
-initDebugger l supportsRunInTerminal preferInternalInterpreter
+initDebugger :: LogAction IO DAPLog -> MVar () -> Bool -> Bool
+             -> LaunchArgs -> ExceptT InitFailed DebugAdaptor (Maybe PortNumber)
+initDebugger l client_proxy_signal supportsRunInTerminal preferInternalInterpreter
                LaunchArgs{ __sessionId
                          , projectRoot = givenRoot
                          , entryFile = entryFileMaybe
@@ -140,7 +144,7 @@ initDebugger l supportsRunInTerminal preferInternalInterpreter
 
   liftIO (runExceptT (hieBiosSetup hieBiosLogger projectRoot entryFile)) >>= \case
     Left e              -> throwError $ InitFailed e
-    Right (Left e)      -> lift       $ exitWithMsg e
+    Right (Left e)      -> lift       $ exitWithMsg e >> pure Nothing
     Right (Right flags) -> do
       -- Create the stdin handle for the external interpreter
       (readExternalIntStdin, writeExternalIntStdin) <- liftIO P.createPipe
@@ -167,10 +171,15 @@ initDebugger l supportsRunInTerminal preferInternalInterpreter
         createDebuggerLogger l dapLogger writeDAPOutput (supportsRunInTerminal, syncProxyOut, syncProxyErr)
 
       let absEntryFile = normalise $ projectRoot </> entryFile
-      lift $ registerNewDebugSession (maybe "debug-session" T.pack __sessionId) DAS{entryFile=absEntryFile,..}
+      let daState = DAS{entryFile=absEntryFile,..}
+      (port, proxyThread) <- do
+        if supportsRunInTerminal then
+          fmap (first Just) . lift $ serverSideHdbProxy (contramap RunProxyServerLog l) client_proxy_signal daState
+          else pure (Nothing,return ())
+      lift $ registerNewDebugSession (maybe "debug-session" T.pack __sessionId) daState
         [ debuggerThread dbgLog finished_init projectRoot flags
             extraGhcArgs absEntryFile defaultRunConf syncRequests syncResponses
-
+        , ($ proxyThread)
         , \withAdaptor -> forwardHandleToLogger readDAPOutput $
             LogAction (\msg -> withAdaptor (Output.neutral msg))
 
@@ -191,13 +200,14 @@ initDebugger l supportsRunInTerminal preferInternalInterpreter
 
       -- Do not return until the initialization is finished
       liftIO (takeMVar finished_init) >>= \case
-        Right () -> pure ()
+        Right () -> pure port
         Left e   -> do
           -- The process terminates cleanly with an error code (probably exit failure = 1)
           -- This can happen if compilation fails and the compiler exits cleanly.
           --
           -- Instead of signalInitialized, respond with error and exit.
           lift $ exitCleanupWithMsg readDAPOutput e
+          pure Nothing
 
 -- | The main debugger thread launches a GHC.Debugger session.
 --

--- a/hdb/Development/Debug/Adapter/Interface.hs
+++ b/hdb/Development/Debug/Adapter/Interface.hs
@@ -28,8 +28,8 @@ sendInterleaved cmd action = do
   liftIO (takeMVar syncResponses) >>= handleAbort
 
 handleAbort :: Response -> DebugAdaptor Response
-handleAbort (Aborted e) = do
+handleAbort r@(Aborted e) = do
   Output.console (T.pack e)
-  exitCleanly (Just e)
+  terminateSessionCleanly (Just e)
+  return r
 handleAbort r = return r
-

--- a/hdb/Development/Debug/Adapter/Proxy.hs
+++ b/hdb/Development/Debug/Adapter/Proxy.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE BlockArguments, OverloadedStrings, DerivingStrategies #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 -- | Run the proxy mode, which forwards stdin/stdout to/from the DAP server and
 -- is displayed in a terminal in the DAP client using 'runInTerminal'
 module Development.Debug.Adapter.Proxy
   ( serverSideHdbProxy
   , runInTerminalHdbProxy
+  , sendRunProxyInTerminal
   ) where
 
 #if !MIN_VERSION_ghc(9,15,0)
@@ -33,6 +35,7 @@ import qualified Data.HashMap.Strict as H
 
 import Colog.Core
 import Development.Debug.Adapter
+import qualified Control.Exception as E
 
 -- | Fork a new thread to run the server-side of the proxy.
 --
@@ -46,11 +49,12 @@ import Development.Debug.Adapter
 -- 2.1 Read from a stdout Chan and write to the socket
 serverSideHdbProxy :: LogAction IO (WithSeverity T.Text)
                    -> MVar ()
-                   -> DebugAdaptor ()
-serverSideHdbProxy l client_conn_signal = do
+                   -> DebugAdaptorState
+                   -> Adaptor DebugAdaptorState r (PortNumber, Adaptor DebugAdaptorState s ())
+serverSideHdbProxy l client_conn_signal
   DAS { syncProxyIn = dbIn
       , syncProxyOut = dbOut
-      , syncProxyErr = dbErr } <- getDebugSession
+      , syncProxyErr = dbErr } = do
 
   sock <- liftIO $ do
     let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
@@ -59,10 +63,10 @@ serverSideHdbProxy l client_conn_signal = do
     openTCPServerSocket addr
 
   port <- liftIO $ socketPort sock
-
-  fwd_thr <- liftIO $ async $ ignoreIOException $ do
+  return $ (port,) $ liftIO $ do
+   ignoreIOException $ do
     myThreadId >>= \tid -> labelThread tid "Debug/Adapter/Proxy: TCP Server"
-    runTCPServerWithSocket sock $ \scket -> do
+    runTCPServerWithSocket' sock $ \scket -> do
 
       infoMsg (T.pack $ "Connected to client on port " ++ show port ++ "...!")
       putMVar client_conn_signal () -- signal ready (see #95)
@@ -71,16 +75,14 @@ serverSideHdbProxy l client_conn_signal = do
         (race_
           (-- Read stdout from chan and write to socket
            ignoreIOException $ do
-             tid <- myThreadId
-             labelThread tid "Debug/Adapter/Proxy: Forward stdout"
+             labelMe "Debug/Adapter/Proxy: Forward stdout"
              forever $ do
                bs <- readChan dbOut
                debugMsg (T.pack $ "Writing to socket: " ++ BS8.unpack bs)
                NBS.sendAll scket bs)
           (-- Read stderr from chan and write to socket
            ignoreIOException $ do
-             tid <- myThreadId
-             labelThread tid "Debug/Adapter/Proxy: Forward stderr"
+             labelMe "Debug/Adapter/Proxy: Forward stderr"
              forever $ do
                bs <- readChan dbErr
                debugMsg (T.pack $ "Writing to socket (from stderr): " ++ BS8.unpack bs)
@@ -96,16 +98,34 @@ serverSideHdbProxy l client_conn_signal = do
               else do
                 debugMsg (T.pack $ "Read from socket: " ++ BS8.unpack bs)
                 writeChan dbIn bs >> loop
-          in ignoreIOException loop)
-
-  liftIO $ link fwd_thr
-  sendRunProxyInTerminal port
+          in ignoreIOException $ do
+              labelMe "Debug/Adapter/Proxy: Read stdin"
+              loop)
 
   where
     ignoreIOException a = catch a $ \(e::IOException) ->
       infoMsg (T.pack $ "Ignoring connection broken to proxy client: " ++ show e)
     debugMsg msg = l <& WithSeverity msg Debug
     infoMsg msg  = l <& WithSeverity msg Info
+
+-- | A version of @runTCPServerWithSocket@ that kills the forked connection
+-- handlers when killed.
+runTCPServerWithSocket' :: Socket -> (Socket -> IO a1) -> IO a2
+runTCPServerWithSocket' sock server = do
+  let
+    serverLoop = forever $ E.bracketOnError (accept sock) (close . fst) $
+      \(conn, _peer) ->
+        mask_ $ withAsyncWithUnmask
+          (\ unmask ->
+             unmask (labelMe "TCP Server handler" >> server conn)
+            `finally` gracefulClose conn 5000)
+          (const serverLoop)
+  serverLoop
+
+labelMe :: String -> IO ()
+labelMe name = do
+    tid <- myThreadId
+    labelThread tid name
 
 -- | The proxy code running on the terminal in which the @hdb proxy@ process is launched.
 --

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -245,19 +245,21 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
 
     merror <- runExceptT $
       initDebugger (contramap DAPLog l)
+        client_proxy_signal
         supportsRunInTerminalRequest prefer_internal_interpreter
         launch_args
     case merror of
-      Right () -> do
+      Right mport -> do
         sendLaunchResponse   -- ack
         sendInitializedEvent -- our debugger is only ready to be configured after it has launched the session
 
         -- Run the proxy in a separate terminal to accept stdin / forward stdout
         -- if it is supported
         when supportsRunInTerminalRequest $ do
+          maybe (pure ()) sendRunProxyInTerminal mport
+
           -- Run proxy thread, server side, and
           -- send the 'runInTerminal' request
-          serverSideHdbProxy (contramap RunProxyServerLog l) client_proxy_signal
 
         liftLogIO l <& DAPLaunchLog (WithSeverity (T.pack "Debugger launched successfully.") Info)
 
@@ -338,7 +340,6 @@ ack l _ref rrr = case rrr.reverseRequestCommand of
 data MainLog
   = DAPLog DAPLog
   | InteractiveLog InteractiveLog
-  | RunProxyServerLog (WithSeverity T.Text)
   | RunProxyClientLog (WithSeverity T.Text)
   | DAPLaunchLog (WithSeverity T.Text)
   | DAPLibraryLog DAP.DAPLog
@@ -377,9 +378,9 @@ mainLogger threshold h = do
   pure $ LogAction $ \case
     DAPLog (DAPSessionSetupLog sessionLog)       -> logSessionLog sessionLog
     DAPLog (DAPDebuggerLog debuggerLog)          -> logDebuggerLog debuggerLog
+    DAPLog (RunProxyServerLog sev_msg) -> defaultLog sev_msg
     InteractiveLog (ISessionSetupLog sessionLog) -> logSessionLog sessionLog
     InteractiveLog (IDebuggerLog debuggerLog)    -> logDebuggerLog debuggerLog
-    RunProxyServerLog sev_msg -> defaultLog sev_msg
     RunProxyClientLog sev_msg -> defaultLog sev_msg
     DAPLaunchLog sev_msg      -> defaultLog sev_msg
     DAPLibraryLog t ->

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -263,11 +263,11 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
 
       Left (InitFailed err) -> do
         sendErrorResponse (ErrorMessage (T.pack err)) Nothing
-        exitCleanly Nothing
+        terminateSessionCleanly Nothing
 --------------------------------------------------------------------------------
   CommandAttach -> do
     sendErrorResponse (ErrorMessage (T.pack "hdb does not support \"attach\" mode yet")) Nothing
-    exitCleanly Nothing
+    terminateSessionCleanly Nothing
 --------------------------------------------------------------------------------
   CommandBreakpointLocations       -> commandBreakpointLocations
   CommandSetBreakpoints            -> commandSetBreakpoints
@@ -315,7 +315,7 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
     pure ()
   other -> do
     sendErrorResponse (ErrorMessage (T.pack ("Unsupported command: " <> show other))) Nothing
-    exitCleanly Nothing
+    terminateSessionCleanly Nothing
 ----------------------------------------------------------------------------
 -- talk cmd = logInfo $ BL8.pack ("GOT cmd " <> show cmd)
 ----------------------------------------------------------------------------

--- a/test/golden/T130/T130.ghc-914.hdb-stdout
+++ b/test/golden/T130/T130.ghc-914.hdb-stdout
@@ -1,1 +1,2 @@
 Cannot use unsupported haskell-debugger-view version found in the transitive closure: 0.1.0.0 (supported: 0.2 <= && < 0.3)
+While handling Cannot use unsupported haskell-debugger-view version found in the transitive closure: 0.1.0.0 (supported: 0.2 <= && < 0.3)

--- a/test/golden/T130/T130.ghc-915.hdb-stdout
+++ b/test/golden/T130/T130.ghc-915.hdb-stdout
@@ -1,1 +1,2 @@
 Cannot use unsupported haskell-debugger-view version found in the transitive closure: 0.1.0.0 (supported: 0.2 <= && < 0.3)
+While handling Cannot use unsupported haskell-debugger-view version found in the transitive closure: 0.1.0.0 (supported: 0.2 <= && < 0.3)

--- a/test/haskell/Main.hs
+++ b/test/haskell/Main.hs
@@ -24,6 +24,7 @@ import Test.Tasty.Golden as G
 import Test.Tasty.Golden.Advanced as G
 
 import Test.DAP.LogMessage
+import Test.DAP.Persistent (persistentTests)
 import Test.DAP.RunInTerminal
 import Test.DAP.Scopes
 import Test.Utils
@@ -71,6 +72,7 @@ unitTests =
   [ runInTerminalTests
   , scopesTests
   , logMessageTests
+  , persistentTests
   ]
 
 -- | Receives as an argument the path to the @*.hdb-test@ which contains the

--- a/test/haskell/Test/DAP/Init.hs
+++ b/test/haskell/Test/DAP/Init.hs
@@ -27,12 +27,12 @@ data TestDAPServer = TestDAPServer
   }
 
 -- | Launch an @hdb server@ for tests on a random local port and capture stdout.
-startTestDAPServer :: FilePath -> String -> IO TestDAPServer
+startTestDAPServer :: FilePath -> [String] -> IO TestDAPServer
 startTestDAPServer testDir flags = do
   testPort <- randomRIO (49152, 65534) :: IO Int
 
   (Just _hin, Just hout, _, p)
-    <- P.createProcess (P.shell $ "hdb server " ++ flags ++ " --port " ++ show testPort)
+    <- P.createProcess (P.proc "hdb" $ ["server"] ++ flags ++ ["--port", show testPort])
         { P.cwd = Just testDir
         , P.std_out = P.CreatePipe
         , P.std_in = P.CreatePipe

--- a/test/haskell/Test/DAP/Init.hs
+++ b/test/haskell/Test/DAP/Init.hs
@@ -65,10 +65,16 @@ startTestDAPServer testDir flags = do
     , testDAPServerFlushOutput = flushServerOutput
     }
 
--- | Connect a test client to a running 'TestDAPServer', with retry semantics
--- and server log flushing on failure.
+-- | Like @withTestDAPServerClient'@ but also shutsdown server on exit.
 withTestDAPServerClient :: TestDAPServer -> TestDAP a -> IO a
 withTestDAPServerClient server continue = do
+  withTestDAPServerClient' server continue
+    `E.finally` P.terminateProcess (testDAPServerProcess server)
+
+-- | Connect a test client to a running 'TestDAPServer', with retry semantics
+-- and server log flushing on failure.
+withTestDAPServerClient' :: TestDAPServer -> TestDAP a -> IO a
+withTestDAPServerClient' server continue = do
   retryVar <- newIORef True
   let runClient =
         withNewClient (testDAPServerPort server) retryVar $ \h -> do
@@ -77,7 +83,6 @@ withTestDAPServerClient server continue = do
           seqRef <- newIORef 1
           runTestDAP continue (TestDAPClientContext h seqRef)
   (runClient `E.onException` testDAPServerFlushOutput server)
-    `E.finally` P.terminateProcess (testDAPServerProcess server)
 
 -- | Spawns a new mock client that connects to the mock server.
 --

--- a/test/haskell/Test/DAP/LogMessage.hs
+++ b/test/haskell/Test/DAP/LogMessage.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE CPP #-}
-module Test.DAP.LogMessage (logMessageTests) where
+module Test.DAP.LogMessage (logMessageTests,hasLogMsg,setupBreakpoints) where
 
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson

--- a/test/haskell/Test/DAP/LogMessage.hs
+++ b/test/haskell/Test/DAP/LogMessage.hs
@@ -47,12 +47,12 @@ logMessageTests =
 
 simpleTest :: String -> String -> IO ()
 simpleTest tmpl expected =
-  logMessageTestSetup "" [(18,Nothing,Just tmpl)] $ do
+  logMessageTestSetup [] [(18,Nothing,Just tmpl)] $ do
     vs <- receiveMessagesUnordered [eventMatch "output"]
     hasLogMsg expected vs
 
 conditionTest :: IO ()
-conditionTest = logMessageTestSetup "" bps $ do
+conditionTest = logMessageTestSetup [] bps $ do
   [v] <- receiveMessagesUnordered [eventMatch "output"]
   Just output <- pure $ getOutput v
   liftIO $ assertBool "logged when False" $
@@ -65,7 +65,7 @@ conditionTest = logMessageTestSetup "" bps $ do
           ,(19,Just "True", Just "DO LOG")
           ]
 
-logMessageTestSetup :: String -> [(Int, Maybe String, Maybe String)] -> TestDAP a -> IO ()
+logMessageTestSetup :: [String] -> [(Int, Maybe String, Maybe String)] -> TestDAP a -> IO ()
 logMessageTestSetup flags bps check = do
   withHermeticDir False "test/unit/T113" $ \test_dir -> do
 

--- a/test/haskell/Test/DAP/Persistent.hs
+++ b/test/haskell/Test/DAP/Persistent.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE CPP #-}
+module Test.DAP.Persistent (persistentTests) where
+
+import Control.Concurrent.Async
+import Test.DAP
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure
+import Test.Utils
+import Test.DAP.LogMessage (hasLogMsg,setupBreakpoints)
+import qualified System.Process as P
+import Control.Exception (bracket)
+
+persistentTests :: TestTree
+persistentTests =
+#ifdef mingw32_HOST_OS
+ ignoreTestBecause "Needs to be fixed for Windows (#199)" $
+#endif
+  testGroup "DAP.Persistent"
+    [
+      testGroup "multiple sessions"
+        [ testCase "sequential" $
+          testSequential [] $ simpleSessions 2
+        , testCase "parallel" $
+          testParallel [] $ simpleSessions 2
+        ]
+    ]
+
+
+withServerTestSetup :: [String] -> (FilePath -> TestDAPServer -> IO a) -> IO a
+withServerTestSetup flags check = do
+  withHermeticDir False "test/unit/T113" $ \test_dir ->
+    bracket (startTestDAPServer test_dir flags)
+      (\server -> P.terminateProcess (testDAPServerProcess server))
+      (check test_dir)
+
+withBreakPoints :: [(Int, Maybe String, Maybe String)] -> TestDAP a -> (FilePath, TestDAPServer) -> IO ()
+withBreakPoints bps check (test_dir,server) =
+     withTestDAPServerClient' server $ do
+      () <- setupBreakpoints test_dir $ bps
+      _ <- check
+
+      -- consume further prints and events
+      expectMessagesUnordered $
+        replicate 3 (eventMatch "output")
+          ++ [eventMatch "terminated", eventMatch "exited"]
+
+      -- Send disconnect
+      disconnectSession
+      pure ()
+
+testSequential :: Foldable t => [String] -> ((FilePath, TestDAPServer) -> t (IO a)) -> IO ()
+testSequential flags k = withServerTestSetup flags (curry $ \ x -> sequence_ $ k x)
+
+testParallel :: Foldable f => [String] -> ((FilePath, TestDAPServer) -> f (IO b)) -> IO ()
+testParallel flags k = withServerTestSetup flags (curry $ \ x -> mapConcurrently_ id (k x))
+
+simpleSessions :: Int -> (FilePath, TestDAPServer) -> [IO ()]
+simpleSessions n x =
+  [withBreakPoints [(18,Nothing,Just msg)] check x
+      | i <- [0..n]
+      , let msg = "MSG_" ++ show i
+      , let
+          check = do
+            vs <- receiveMessagesUnordered [eventMatch "output"]
+            hasLogMsg msg vs
+      ]

--- a/test/haskell/Test/DAP/RunInTerminal.hs
+++ b/test/haskell/Test/DAP/RunInTerminal.hs
@@ -27,8 +27,8 @@ runInTerminalTests =
       ignoreTestBecause "Needs to be fixed for Windows (#199)" $
 #endif
       testGroup "runInTerminal: proxy forwards stdin correctly"
-        [ testCase "(default)" (runInTerminal1 "")
-        , testCase "(--internal-interpreter)" (runInTerminal1 "--internal-interpreter")
+        [ testCase "(default)" (runInTerminal1 [])
+        , testCase "(--internal-interpreter)" (runInTerminal1 ["--internal-interpreter"])
         ]
     ]
 

--- a/test/haskell/Test/DAP/Scopes.hs
+++ b/test/haskell/Test/DAP/Scopes.hs
@@ -21,7 +21,7 @@ scopesTests =
 
 scopesExpensiveTest :: Assertion
 scopesExpensiveTest = withHermeticDir False "test/unit/T44" $ \test_dir -> do
-  server <- startTestDAPServer test_dir "--disable-ipe-backtraces"
+  server <- startTestDAPServer test_dir ["--disable-ipe-backtraces"]
 
   withTestDAPServerClient server $ do
 


### PR DESCRIPTION
The goal is to let a user connect and run a debug session multiple times from the same project, while not leaking threads.

TODOs:
- ~~[ ] Should this be behind a flag?~~ Things seem to work fine without
- ~~[ ] call registerNewDebugSession from `initialize` handler already?~~ No sessionId yet.
- [x] rename exitCleanly to terminateSessionCleanly
- [x] unit test
- [x] squash wip commits