### PR TITLE
CI: Cache GHC for macOS

### DIFF
--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -154,6 +154,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: "Cache GHC for macOS" # See haskell-actions/setup#139
+        id: cache-haskell
+        uses: actions/cache@v5
+        if: matrix.runner == 'macOS-latest'
+        with:
+          path: ~/.ghcup
+          key: ${{ runner.os }}-ghc-${{ matrix.version }}
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.version }}
+
       - uses: haskell-actions/setup@v2
         id: setup
         with:


### PR DESCRIPTION
The macOS runner doesn't come with ghc and we are reinstalling it from scratch every time, making the macOS setup step take 5 minutes rather than seconds.

We cache only on macOS just to limit cache size usage (apparently it's only 10GB total)