### PR TITLE
[Fix #263] Avoid CWD change for GHC session 

### DIFF
--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -100,7 +100,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.version }}
-          cabal-version: 3.14
+          cabal-version: 3.16
           ghcup-release-channel: ${{ matrix.channel }}
 
       - uses: cachix/install-nix-action@v31
@@ -167,7 +167,7 @@ jobs:
         id: setup
         with:
           ghc-version: ${{ matrix.version }}
-          cabal-version: 3.14
+          cabal-version: 3.16
           ghcup-release-channel: ${{ matrix.channel }}
 
       - name: Configure the build

--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -188,7 +188,9 @@ executable hdb
         dap >= 0.4 && < 0.5,
 
         haskeline >= 0.8 && < 1,
-        optparse-applicative >= 0.18 && < 0.20
+        optparse-applicative >= 0.18 && < 0.20,
+        uuid >= 1.3 && < 1.4,
+
     hs-source-dirs:   hdb
     default-language: GHC2021
     default-extensions: CPP

--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -170,6 +170,7 @@ executable hdb
         exceptions, aeson, bytestring,
         containers, filepath,
         process, mtl,
+        stm,
         unordered-containers >= 0.2.19 && < 0.3,
 
         haskell-debugger,

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -40,6 +40,7 @@ import GHC
 import GHC.Data.FastString
 import GHC.Data.StringBuffer
 import GHC.Driver.Config.Diagnostic
+import GHC.Driver.Config.Logger
 import GHC.Driver.DynFlags as GHC
 import GHC.Driver.Env
 import GHC.Driver.Monad
@@ -49,6 +50,7 @@ import GHC.Driver.Errors.Types
 import GHC.Driver.Main
 import GHC.Driver.Make
 import GHC.Driver.Ppr
+import GHC.Driver.Session (parseDynamicFlagsCmdLine)
 import GHC.Runtime.Eval
 import GHC.Runtime.Heap.Inspect
 import GHC.Runtime.Interpreter as GHCi
@@ -262,7 +264,7 @@ runDebugger l rootDir compDir libdir units ghcInvocation' extraGhcArgs mainFp co
       -- 3093efa27468fb2d31a617f6a0e4ff67a90f6623 tried to fix (but had to be
       -- reverted)
       (dflags2, fileish_args, warns)
-        <- parseDynamicFlags logger dflags1 (map noLoc extraGhcArgs)
+        <- parseDynamicFlagsWithRootDir rootDir logger dflags1 (map noLoc extraGhcArgs)
       liftIO $ printOrThrowDiagnostics logger (initPrintConfig dflags2) (initDiagOpts dflags2) (GhcDriverMessage <$> warns)
       forM_ fileish_args $ \fish_arg -> liftIO $ do
         GHC.logMsg logger MCOutput noSrcSpan $ text "Ignoring extraGhcArg which isn't a recognized flag:" <+> text (unLoc fish_arg)
@@ -439,6 +441,24 @@ runDebugger l rootDir compDir libdir units ghcInvocation' extraGhcArgs mainFp co
 -- | WARNING: callback is not to be used from other threads.
 withUnliftGhc :: ((Ghc b -> IO b) -> IO a) -> Ghc a
 withUnliftGhc k = reifyGhc $ \ s -> k (flip reflectGhc s)
+
+-- | Variant of GHC's parseDynamicFlags which interprets paths relative to first arg.
+parseDynamicFlagsWithRootDir
+    :: MonadIO m
+    => FilePath
+    -> Logger
+    -> DynFlags
+    -> [Located String]
+    -> m (DynFlags, [Located String], Messages DriverMessage)
+parseDynamicFlagsWithRootDir rootDir logger dflags cmdline = do
+  (dflags1', leftovers, warns) <- parseDynamicFlagsCmdLine logger dflags cmdline
+  -- flags that have just been read are used by the logger when loading package
+  -- env
+  let dflags1 = makeDynFlagsAbsoluteOverall rootDir dflags1'
+  let logger1 = GHC.setLogFlags logger (initLogFlags dflags1)
+  dflags2 <- liftIO $ interpretPackageEnv logger1 dflags1
+  return (dflags2, leftovers, warns)
+
 
 {-
 Note [Custom external interpreter]

--- a/haskell-debugger/GHC/Debugger/Session.hs
+++ b/haskell-debugger/GHC/Debugger/Session.hs
@@ -25,7 +25,8 @@ module GHC.Debugger.Session (
   enableExternalInterpreter,
   enableDynamicDebuggee,
   setPgmI, addOptI,
-  setDynFlagWays
+  setDynFlagWays,
+  makeDynFlagsAbsoluteOverall,
   )
   where
 
@@ -120,6 +121,7 @@ parseHomeUnitArguments cfp compRoot units theOpts dflags rootDir = do
         let targets = HIE.makeTargetsAbsolute root_canon targets'
         cacheDirs <- liftIO $ getCacheDirs (takeFileName root) this_opts
         let dflags'' =
+              makeDynFlagsDirsAbsolute compRoot $
               setWorkingDirectory root $
               setCacheDirs cacheDirs $
               enableByteCodeGeneration $
@@ -402,6 +404,18 @@ setCacheDirs CacheDirs{..} flags = flags
   , bytecodeDir = Just byteCodeCacheDir
 #endif
   }
+
+-- | Prefixes output directories (i.e. @hiDir@, @hieDir@, @stubDir@, @dumpDir@) with @rootDir@ argument.
+makeDynFlagsDirsAbsolute :: FilePath -> DynFlags -> DynFlags
+makeDynFlagsDirsAbsolute rootDir df0 =
+  foldl' (\ df f -> f (fmap $ normalise . (rootDir </>)) df) df0
+    [(\ f df -> df {hiDir = f (hiDir df)})
+    ,(\ f df -> df {hieDir = f (hieDir df)})
+    ,(\ f df -> df {stubDir = f (stubDir df)})
+    ,(\ f df -> df {dumpDir = f (dumpDir df)})]
+
+makeDynFlagsAbsoluteOverall :: FilePath -> DynFlags -> DynFlags
+makeDynFlagsAbsoluteOverall rootDir df0 = makeDynFlagsDirsAbsolute rootDir $ makeDynFlagsAbsolute rootDir df0
 
 -- | If the compiler supports `.gbc` files (>= 9.14.2), then persist these
 -- artefacts to disk.

--- a/hdb/Development/Debug/Adapter/Breakpoints.hs
+++ b/hdb/Development/Debug/Adapter/Breakpoints.hs
@@ -7,6 +7,7 @@ import qualified Data.IntSet as IS
 import Text.Read
 import Control.Monad
 import Data.Maybe
+import System.FilePath ((</>), normalise)
 
 import qualified GHC
 
@@ -155,8 +156,9 @@ registerNewBreakpoint breakpoint = do
 -- TODO: Handles sourceReferences too
 fileFromSourcePath :: Source -> DebugAdaptor FilePath
 fileFromSourcePath source = do
+  prjRoot <- projectRoot <$> getDebugSession
   let
     file = T.unpack $
             fromMaybe (error "sourceReference unsupported") $
               sourcePath source
-  return file
+  return $ normalise $ prjRoot </> file

--- a/hdb/Development/Debug/Adapter/Init.hs
+++ b/hdb/Development/Debug/Adapter/Init.hs
@@ -101,7 +101,7 @@ newtype InitFailed = InitFailed String deriving Show
 -- | Initialize debugger
 --
 -- Returns @()@ if successful, throws @InitFailed@ otherwise
-initDebugger :: LogAction IO DAPLog -> MVar () -> Bool -> Bool
+initDebugger :: LogAction IO DAPLog -> IO () -> Bool -> Bool
              -> LaunchArgs -> ExceptT InitFailed DebugAdaptor (Maybe PortNumber)
 initDebugger l client_proxy_signal supportsRunInTerminal preferInternalInterpreter
                LaunchArgs{ __sessionId

--- a/hdb/Development/Debug/Adapter/Init.hs
+++ b/hdb/Development/Debug/Adapter/Init.hs
@@ -218,14 +218,6 @@ initDebugger l client_proxy_signal supportsRunInTerminal preferInternalInterpret
 --
 -- Concurrently, it reads from the process's stderr forever and outputs it through OutputEvents.
 --
--- Notes:
---
--- (CWD):
---    It's necessary for the GHC session to be run in the project root.
---    We do this by setting the current directory on initialize.
---    This sets the global CWD for this process, disallowing multiple sessions
---    at the same, but that's OK because we currently only support
---    single-session mode. Each new session gets a new debugger process.
 debuggerThread :: LogAction IO Debugger.DebuggerLog
                -> MVar (Either String ()) -- ^ To signal when initialization is complete.
                -> FilePath        -- ^ Working directory for GHC session
@@ -238,10 +230,7 @@ debuggerThread :: LogAction IO Debugger.DebuggerLog
                -> (DebugAdaptorCont () -> IO ())
                -- ^ Allows unlifting DebugAdaptor actions to IO. See 'registerNewDebugSession'.
                -> IO ()
-debuggerThread l finished_init workDir HieBiosFlags{..} extraGhcArgs mainFp runConf requests replies withAdaptor = do
-
-  -- See Notes (CWD) above
-  setCurrentDirectory workDir
+debuggerThread l finished_init _workDir HieBiosFlags{..} extraGhcArgs mainFp runConf requests replies withAdaptor = do
 
   -- Log haskell-debugger invocation
   withAdaptor $

--- a/hdb/Development/Debug/Adapter/Init.hs
+++ b/hdb/Development/Debug/Adapter/Init.hs
@@ -27,6 +27,7 @@ import Data.Bifunctor
 import Data.Function
 import Data.Functor
 import Data.Maybe
+import Data.UUID.V4 qualified as UUID
 import System.IO
 import GHC.IO.Encoding
 import Control.Monad.Catch
@@ -176,7 +177,8 @@ initDebugger l client_proxy_signal supportsRunInTerminal preferInternalInterpret
         if supportsRunInTerminal then
           fmap (first Just) . lift $ serverSideHdbProxy (contramap RunProxyServerLog l) client_proxy_signal daState
           else pure (Nothing,return ())
-      lift $ registerNewDebugSession (maybe "debug-session" T.pack __sessionId) daState
+      sessionId <- liftIO $ maybe (("debug-session:" <>) . T.show <$> UUID.nextRandom) (pure . T.pack) __sessionId
+      lift $ registerNewDebugSession sessionId daState
         [ debuggerThread dbgLog finished_init projectRoot flags
             extraGhcArgs absEntryFile defaultRunConf syncRequests syncResponses
         , ($ proxyThread)

--- a/hdb/Development/Debug/Adapter/Proxy.hs
+++ b/hdb/Development/Debug/Adapter/Proxy.hs
@@ -48,7 +48,7 @@ import qualified Control.Exception as E
 -- 2.1 Read stdin from the socket and push it to a Chan
 -- 2.1 Read from a stdout Chan and write to the socket
 serverSideHdbProxy :: LogAction IO (WithSeverity T.Text)
-                   -> MVar ()
+                   -> IO ()
                    -> DebugAdaptorState
                    -> Adaptor DebugAdaptorState r (PortNumber, Adaptor DebugAdaptorState s ())
 serverSideHdbProxy l client_conn_signal
@@ -69,7 +69,7 @@ serverSideHdbProxy l client_conn_signal
     runTCPServerWithSocket' sock $ \scket -> do
 
       infoMsg (T.pack $ "Connected to client on port " ++ show port ++ "...!")
-      putMVar client_conn_signal () -- signal ready (see #95)
+      client_conn_signal -- signal ready (see #95)
 
       race_
         (race_

--- a/hdb/Development/Debug/Session/Setup.hs
+++ b/hdb/Development/Debug/Session/Setup.hs
@@ -15,6 +15,7 @@ module Development.Debug.Session.Setup
   ) where
 
 import Control.Applicative ((<|>))
+import Control.Concurrent (newMVar, MVar, withMVar)
 import Control.Exception (handleJust)
 import Control.Monad
 import Control.Monad.Except
@@ -26,11 +27,13 @@ import Data.Functor ((<&>))
 import Data.Maybe
 import Data.Version
 import Data.Void
-import System.Directory hiding (findFile)
+import System.Directory hiding (withCurrentDirectory, findFile)
+import System.Directory qualified as D
 import System.FilePath
 import System.IO.Error
 import Text.ParserCombinators.ReadP (readP_to_S)
 import Data.Functor.Contravariant
+import GHC.IO (unsafePerformIO)
 
 import qualified Data.Text as T
 
@@ -345,3 +348,10 @@ forgetPatchVersion :: Version -> Version
 forgetPatchVersion v = case versionBranch v of
   (major:minor:_patches) -> makeVersion [major, minor]
   _ -> v
+
+{-# NOINLINE cwdLock #-}
+cwdLock :: MVar ()
+cwdLock = unsafePerformIO $ newMVar ()
+
+withCurrentDirectory :: FilePath -> IO b -> IO b
+withCurrentDirectory fp m = withMVar cwdLock $ \ _ -> D.withCurrentDirectory fp m

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -7,8 +7,11 @@ import System.Process
 import System.Environment
 import Data.Maybe
 import Data.IORef
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Text.Read
 import Control.Concurrent
+import Control.Concurrent.STM
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Except
@@ -77,7 +80,7 @@ main = do
         l <- mainLogger hdbOpts.verbosity realStdout
         init_var <- liftIO (newIORef False{-not supported by default-})
         pid_var  <- liftIO (newIORef Nothing)
-        ccon_var <- liftIO newEmptyMVar
+        ccon_var <- liftIO $ newTVarIO Set.empty
         runDAPServerWithLogger (contramap DAPLibraryLog l) config
           (talk l init_var pid_var ccon_var internalInterpreter)
           (ack l pid_var)
@@ -214,7 +217,7 @@ talk :: LogAction IO MainLog
      -- ^ Whether the client supports runInTerminal
      -> IORef (Maybe Int)
      -- ^ The PID of the runInTerminal proxy process
-     -> MVar ()
+     -> TVar (Set ThreadId)
      -- ^ A var to block on waiting for the proxy client to connect, if a proxy
      -- connection is expected. See #95.
      -> Bool
@@ -235,17 +238,18 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
     sendInitializeResponse
 
     -- If runInTerminal is not supported by the client, signal readiness right away
-    when (not runInTerminal) $
-      liftIO $ putMVar client_proxy_signal ()
+    when (not runInTerminal) $ do
+      liftIO $ join $ signalThisThread client_proxy_signal
+
 --------------------------------------------------------------------------------
   CommandLaunch -> do
     launch_args <- getArguments
 
     supportsRunInTerminalRequest <- liftIO $ readIORef support_rit_var
-
+    signal <- liftIO $ signalThisThread client_proxy_signal
     merror <- runExceptT $
       initDebugger (contramap DAPLog l)
-        client_proxy_signal
+        signal
         supportsRunInTerminalRequest prefer_internal_interpreter
         launch_args
     case merror of
@@ -286,7 +290,7 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
     -- now that it has been configured, start executing until it halts, then send an event
 
     -- wait for the proxy client to connect before starting the execution (#95)
-    () <- liftIO $ takeMVar client_proxy_signal
+    () <- liftIO $ blockForSignal client_proxy_signal
     startExecution >>= handleEvalResult False
 ----------------------------------------------------------------------------
   CommandThreads    -> commandThreads
@@ -318,6 +322,24 @@ talk l support_rit_var _pid_var client_proxy_signal prefer_internal_interpreter 
   other -> do
     sendErrorResponse (ErrorMessage (T.pack ("Unsupported command: " <> show other))) Nothing
     terminateSessionCleanly Nothing
+
+
+-- | Waits until own ThreadId appears in var, then deletes it.
+blockForSignal :: TVar (Set ThreadId) -> IO ()
+blockForSignal x = do
+  thId <- myThreadId
+  atomically $ do
+    ths <- readTVar x
+    if Set.member thId ths
+      then writeTVar x (Set.delete thId ths)
+      else retry
+
+-- | Returns an action that adds to the var the ThreadId @signalThisThread@ was called from.
+signalThisThread :: TVar (Set ThreadId) -> IO (IO ())
+signalThisThread x = do
+  thId <- liftIO $ myThreadId
+  pure $ atomically $ modifyTVar x (Set.insert thId)
+
 ----------------------------------------------------------------------------
 -- talk cmd = logInfo $ BL8.pack ("GOT cmd " <> show cmd)
 ----------------------------------------------------------------------------

--- a/test/haskell/Test/DAP/Persistent.hs
+++ b/test/haskell/Test/DAP/Persistent.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ViewPatterns #-}
 module Test.DAP.Persistent (persistentTests) where
 
 import Control.Concurrent.Async
@@ -13,6 +14,7 @@ import Test.Utils
 import Test.DAP.LogMessage (hasLogMsg,setupBreakpoints)
 import qualified System.Process as P
 import Control.Exception (bracket)
+import Data.Bifunctor
 
 persistentTests :: TestTree
 persistentTests =
@@ -26,6 +28,19 @@ persistentTests =
           testSequential [] $ simpleSessions 2
         , testCase "parallel" $
           testParallel [] $ simpleSessions 2
+        , testGroup "cwd /= test_dir" $ do
+            let units = replicate 2 ("test/unit/T113",(18,[]))
+            [ testCase "sequential" $ testSequential' units [] $ simpleSessions'
+             , testCase "parallel" $ testParallel' units [] $ simpleSessions'
+             ]
+        , testGroup "multiple test_dirs" $ do
+            let units = concat $ replicate 2
+                  [ ("test/unit/T113",(18,[]))
+                  , ("test/unit/T44" ,(5,[eventMatch "output"]))
+                  ]
+            [  testCase "sequential" $ testSequential' units [] $ simpleSessions'
+             , testCase "parallel" $ testParallel' units [] $ simpleSessions'
+             ]
         ]
     ]
 
@@ -37,34 +52,80 @@ withServerTestSetup flags check = do
       (\server -> P.terminateProcess (testDAPServerProcess server))
       (check test_dir)
 
+withServerTestSetup' :: [FilePath] -> [String] -> ([FilePath] -> TestDAPServer -> IO a) -> IO a
+withServerTestSetup' dirs0 flags check = bracket (startTestDAPServer "." flags)
+      (\server -> P.terminateProcess (testDAPServerProcess server))
+      (go [] dirs0)
+
+  where
+    go acc [] server = check (reverse acc) server
+    go acc (d:ds) server = withHermeticDir False d $ \test_dir ->
+      go (test_dir:acc) ds server
+
 withBreakPoints :: [(Int, Maybe String, Maybe String)] -> TestDAP a -> (FilePath, TestDAPServer) -> IO ()
 withBreakPoints bps check (test_dir,server) =
      withTestDAPServerClient' server $ do
       () <- setupBreakpoints test_dir $ bps
       _ <- check
 
-      -- consume further prints and events
-      expectMessagesUnordered $
-        replicate 3 (eventMatch "output")
-          ++ [eventMatch "terminated", eventMatch "exited"]
-
       -- Send disconnect
       disconnectSession
       pure ()
 
 testSequential :: Foldable t => [String] -> ((FilePath, TestDAPServer) -> t (IO a)) -> IO ()
-testSequential flags k = withServerTestSetup flags (curry $ \ x -> sequence_ $ k x)
+testSequential flags k
+  = withServerTestSetup flags
+      (curry $ \ x -> sequence_ $ k x)
+
+testSequential' :: Foldable t =>
+  [(FilePath,(Int,[MessageMatch]))] ->
+  [String] ->
+  ([(Int,[MessageMatch])] -> ([FilePath], TestDAPServer) -> t (IO a)) ->
+  IO ()
+testSequential' (unzip -> (dirs,bps)) flags k
+  = withServerTestSetup' dirs flags
+      (curry $ \ x -> sequence_ $ k bps x)
 
 testParallel :: Foldable f => [String] -> ((FilePath, TestDAPServer) -> f (IO b)) -> IO ()
-testParallel flags k = withServerTestSetup flags (curry $ \ x -> mapConcurrently_ id (k x))
+testParallel flags k
+  = withServerTestSetup flags
+      (curry $ \ x -> mapConcurrently_ id (k x))
+
+testParallel' :: Foldable f =>
+  [(FilePath,(Int,[MessageMatch]))] ->
+  [String] ->
+  ([(Int,[MessageMatch])] -> ([FilePath], TestDAPServer) -> f (IO b)) ->
+  IO ()
+testParallel' (unzip -> (dirs,bps)) flags k
+  = withServerTestSetup' dirs flags
+      (curry $ \ x -> mapConcurrently_ id (k bps x))
 
 simpleSessions :: Int -> (FilePath, TestDAPServer) -> [IO ()]
 simpleSessions n x =
   [withBreakPoints [(18,Nothing,Just msg)] check x
-      | i <- [0..n]
+      | i <- [(0::Int)..n]
       , let msg = "MSG_" ++ show i
       , let
           check = do
             vs <- receiveMessagesUnordered [eventMatch "output"]
             hasLogMsg msg vs
+                  -- consume further prints and events
+            expectMessagesUnordered $
+              replicate 3 (eventMatch "output")
+                ++ [eventMatch "terminated", eventMatch "exited"]
+
+      ]
+
+-- simpleSessions' :: [(Int,_)] -> ([FilePath], TestDAPServer) -> [IO ()]
+simpleSessions' ls (dirs,server) =
+  [withBreakPoints [ (line,Nothing,Just msg)
+                   , (line+1,Nothing,Nothing)
+                   ] check (d,server)
+      | (i,((line,matches),d)) <- zip [(0::Int)..] $ zip ls dirs
+      , let msg = "MSG_" ++ show i
+      , let
+          check = do
+            vs <- receiveMessagesUnordered [eventMatch "output"]
+            hasLogMsg msg vs
+            expectMessagesUnordered $ matches ++ [eventMatch "stopped"]
       ]


### PR DESCRIPTION
This PR limits changes to CWD to `hieBiosSetup`  (which are needed for `hie.yaml` like  `cradle: {bios: {program: "./hadrian/hie-bios"}}` or especially `shell` I suppose, since "program" could be resolved to an absolute path.

I wonder what's a good testcase for this. I tried to set relative paths in OPTIONS_GHC to break it, but they mostly seem ignored anyway.

- [x] make DynFlags absolute again after including extraGhcArgs.
- [x] cleanup commits
- [x] use a lock to avoid concurrent calls to `withCurrentDirectory`
- [x] tests 

An issue maybe is that the debugee will be run from the CWD of the server, which might not be what you'd expect.
- If the server is remote I guess it can't be helped? 
- For when the IDE/client is starting hdb can we assume it is getting started from the project root? Which seems fine UX.
- A locally run `hdb server` is where you might really surprise users. For the external interpreter we could change its CWD, but not for the internal one.