### PR TITLE
Forcing a thunk invalidates all threads

### DIFF
--- a/hdb/Development/Debug/Adapter/Stopped.hs
+++ b/hdb/Development/Debug/Adapter/Stopped.hs
@@ -148,7 +148,6 @@ commandVariables = do
         ForcedVariable _
           -> sendInvalidatedEvent defaultInvalidatedEvent
               { invalidatedEventAreas = [InvalidatedAreasVariables]
-              , invalidatedEventStackFrameId = Just 0 -- TODO: REVERSE LOOKUP OF (StackFrameIx threadId frameIx)
               }
         VariableFields _ -> return ()
 


### PR DESCRIPTION
    Forcing any thunk may trigger updates in how values in any other threads
    are displayed. Previously, we triggered the invalidated event only on
    the hardcoded frame == 0, which is wrong in many ways.

    The right thing to do is omit `threadId` and `stackFrameId` altogether,
    as that means "invalidate across all threads".

    DAP specifies these Invalidated Event fields as:
    ```
        /**
         * If specified, the client only needs to refetch data related to this
         * thread.
         */
        threadId?: number;

        /**
         * If specified, the client only needs to refetch data related to this stack
         * frame (and the `threadId` is ignored).
         */
        stackFrameId?: number;
    ```

Fixes #216