### PR TITLE
test: IM value remains forced after refreshing var

### DIFF
--- a/test/haskell/Test/Integration/Variables.hs
+++ b/test/haskell/Test/Integration/Variables.hs
@@ -33,6 +33,7 @@ variableTests =
     , testCase "hdv with containers (issue #47c)" hdvContainersDepTest
     , testCase "hdv in-memory with containers (issue #47d)" hdvContainersMemTest
     , testCase "hdv in-memory with text (issue #47e)" hdvTextMemTest
+    , testCase "force thunk in IntMap value persists (issue #47f)" thunkIntMapTest
     ]
 
 intsAndStringsTest :: Assertion
@@ -319,3 +320,27 @@ hdvTextMemTest =
       action <- forceLazy (locals % "action")
       action @==? "\"this should be displayed as a simple string\""
       disconnect
+
+-- | An IntMap with lazy thunk values. The field value is the actual IntMap
+-- elem heap value, so forcing it is persisted across refreshes (because we're
+-- still referring to the same heap value, and now it happens to be forced)
+thunkIntMapTest :: Assertion
+thunkIntMapTest =
+  withTestDAPServer "test/integration/T47f" [] $ \test_dir server ->
+    withTestDAPServerClient server $ do
+      let cfg = mkLaunchConfig test_dir "Main.hs"
+      hitBreakpointWith cfg 12
+      locals <- fetchLocalVars
+      action <- forceLazy (locals % "action")
+      action @==? "IntMap"
+      ac <- expandVar action
+      v1 <- forceLazy (ac % "1")
+      v1 @==? "5050"
+
+      -- Re-request the parent and check the previously-forced value remains
+      -- evaluated (no force needed).
+      locals2 <- fetchLocalVars
+      ac2 <- expandVar (locals2 % "action")
+      (ac2 % "1") @==? "5050"
+      disconnect
+

--- a/test/integration/T47f/Main.hs
+++ b/test/integration/T47f/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+-- IntMap with lazy thunk values: the thunk lives in the real data
+-- structure, so forcing it persists across debugFields calls.
+
+import qualified Data.IntMap.Lazy as IM
+
+main :: IO ()
+main = f (IM.fromList [(1, sum [1 .. 100 :: Int]), (2, sum [1 .. 200 :: Int])])
+
+f :: Show a => a -> IO ()
+f action = do
+    print action

--- a/test/integration/T47f/T47f.cabal
+++ b/test/integration/T47f/T47f.cabal
@@ -1,0 +1,17 @@
+cabal-version:   3.14
+name:            T47f
+version:         0.1.0.0
+license:         NONE
+author:          Rodrigo Mesquita
+maintainer:      rodrigo.m.mesquita@gmail.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+executable t47f
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base, containers
+    hs-source-dirs:   .
+    default-language: Haskell2010


### PR DESCRIPTION
Unlike in #301, the `DebugView` instance for `IntMap` displays as a
`debugFields` value the actual heap referenced stored in the `IntMap`.

This means that forcing an IM value once, then displaying with `DebugView` the
same IntMap a second time, should display the IM value still forced.
Because the heap reference is the same.

This commit just adds a test which asserts this (it wasn't tested
before).
