### PR TITLE
filter DapLibraryLog by verbosity too

### DIFF
--- a/hdb-dap/Development/Debug/Adapter/Server.hs
+++ b/hdb-dap/Development/Debug/Adapter/Server.hs
@@ -275,8 +275,14 @@ logDAPLog logGhcLog l threshold = LogAction $ \case
       DAPSessionLog (DAPDebuggerLog debuggerLog)          -> logDebuggerLog logGhcLog l threshold debuggerLog
       DAPSessionLog (RunProxyServerLog sev_msg) -> defaultLog l threshold sev_msg
       DAPLaunchLog sev_msg      -> defaultLog l threshold sev_msg
-      DAPLibraryLog t ->
+      DAPLibraryLog t | convert t.severity >= threshold ->
         l <& DAP.renderDAPLog t
+        | otherwise -> pure ()
+  where
+    convert DAP.DEBUG = Debug
+    convert DAP.INFO = Info
+    convert DAP.WARN = Warning
+    convert DAP.ERROR = Error
 
 renderSeverity :: Severity -> Text
 renderSeverity = \case


### PR DESCRIPTION
`hdb server -v0 --port ...` should only output messages of severity Error, currently it prints more than that.

Here we fix the major source of messages: logging from the debug library.

Other sources:
- stray putStrLn
- GHC logger


