### PR TITLE
[Fix #38] Use LoadUnitsFromCradle new hie-bios mode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,6 @@ if !os(windows)
 if impl(ghc >10.0)
     constraints:
         hashable==1.4.7.0
-        , hie-bios>=0.20
 
     allow-newer:
         ghc-boot-th,

--- a/cabal.project
+++ b/cabal.project
@@ -18,13 +18,9 @@ if !os(windows)
     executable-dynamic: True
 
 if impl(ghc >10.0)
-    source-repository-package
-        type: git
-        location: https://github.com/fendor/hie-bios.git
-        tag: 7e691c82e554c7e0b8fbfb6748d3a1659911eaf8
-
     constraints:
         hashable==1.4.7.0
+        , hie-bios>=0.20
 
     allow-newer:
         ghc-boot-th,

--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -185,7 +185,7 @@ library dap-server
         unordered-containers >= 0.2.19 && < 0.3,
 
         haskell-debugger,
-        hie-bios,
+        hie-bios ^>= 0.20,
         prettyprinter ^>= 1.7.0,
         co-log-core >= 0.3.2.5 && < 0.4,
         implicit-hie ^>=0.1.4.0,

--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -138,7 +138,7 @@ library
                       cryptohash-sha1 >= 0.11.101.0 && < 0.12,
                       base16-bytestring >= 1.0.2.0 && < 1.1,
                       aeson >= 2.2.3 && < 2.3,
-                      hie-bios >= 0.15 && < 0.20,
+                      hie-bios >= 0.15 && < 0.21,
                       file-embed >= 0.0.16 && < 0.1,
                       attoparsec >= 0.13 && < 0.15,
                       time >= 1.14 && < 2,
@@ -155,7 +155,7 @@ library
     hs-source-dirs:   haskell-debugger
     default-language: GHC2021
 
-library dap
+library dap-server
     import:           warnings
     exposed-modules:  Development.Debug.Adapter.Breakpoints,
                       Development.Debug.Adapter.Stepping,
@@ -222,7 +222,7 @@ executable hdb
         unordered-containers >= 0.2.19 && < 0.3,
 
         haskell-debugger,
-        haskell-debugger:dap,
+        haskell-debugger:dap-server,
         hie-bios,
         prettyprinter ^>= 1.7.0,
         co-log-core >= 0.3.2.5 && < 0.4,

--- a/hdb-dap/Development/Debug/Session/Setup.hs
+++ b/hdb-dap/Development/Debug/Session/Setup.hs
@@ -186,7 +186,9 @@ hieBiosFlags cradle root relTarget = runExceptT $ do
   -- because hie.yaml may invoke programs relative to the root (e.g. GHC's hie.yaml does)
   -- (HIE.getCompilerOptions depends on CWD being the proper root dir)
   let compilerOpts = liftIO $ withCurrentDirectory root $
-#if MIN_VERSION_hie_bios(0,14,0)
+#if MIN_VERSION_hie_bios(0,20,0)
+                          HIE.getCompilerOptions (HIE.TargetWithContext target [target]) HIE.LoadUnitsFromCradle cradle
+#elif MIN_VERSION_hie_bios(0,14,0)
                           HIE.getCompilerOptions target (HIE.LoadWithContext [target]) cradle
 #else
                           HIE.getCompilerOptions target [] cradle
@@ -309,12 +311,18 @@ stackCradle fp = do
   pkgsWithComps <- liftIO $ catMaybes <$> mapM (Implicit.nestedPkg fp) pkgs
   let yaml = fp </> "stack.yaml"
   pure $ (,fp) $ case pkgsWithComps of
-    [] -> Config.Stack (Config.StackType Nothing (Just yaml))
+    [] -> Config.Stack (mkStackType Nothing (Just yaml))
     ps -> Config.StackMulti mempty $ do
       Implicit.Package n cs <- ps
       c <- cs
       let (prefix, comp) = Implicit.stackComponent n c
-      pure (prefix, Config.StackType (Just comp) (Just yaml))
+      pure (prefix, mkStackType (Just comp) (Just yaml))
+  where
+#if MIN_VERSION_hie_bios(0,20,0)
+    mkStackType a b = Config.StackType a b Nothing
+#else
+    mkStackType a b = Config.StackType a b
+#endif
 
 -- | By default, we generate a simple cabal cradle which is equivalent to the
 -- following hie.yaml:
@@ -326,7 +334,11 @@ stackCradle fp = do
 --
 -- Note, this only works reliable for reasonably modern cabal versions >= 3.2.
 simpleCabalCradle :: FilePath -> (Config.CradleTree a, FilePath)
+#if MIN_VERSION_hie_bios(0,20,0)
+simpleCabalCradle fp = (Config.Cabal $ Config.CabalType Nothing Nothing Nothing, fp)
+#else
 simpleCabalCradle fp = (Config.Cabal $ Config.CabalType Nothing Nothing, fp)
+#endif
 
 cabalExecutable :: MaybeT IO FilePath
 cabalExecutable = MaybeT $ findExecutable "cabal"

--- a/hdb-dap/Development/Debug/Session/Setup.hs
+++ b/hdb-dap/Development/Debug/Session/Setup.hs
@@ -186,13 +186,7 @@ hieBiosFlags cradle root relTarget = runExceptT $ do
   -- because hie.yaml may invoke programs relative to the root (e.g. GHC's hie.yaml does)
   -- (HIE.getCompilerOptions depends on CWD being the proper root dir)
   let compilerOpts = liftIO $ withCurrentDirectory root $
-#if MIN_VERSION_hie_bios(0,20,0)
                           HIE.getCompilerOptions (HIE.TargetWithContext target [target]) HIE.LoadUnitsFromCradle cradle
-#elif MIN_VERSION_hie_bios(0,14,0)
-                          HIE.getCompilerOptions target (HIE.LoadWithContext [target]) cradle
-#else
-                          HIE.getCompilerOptions target [] cradle
-#endif
   componentOpts <- compilerOpts >>= unwrapCradleResult "Failed to get compiler options using hie-bios cradle"
 #if __GLASGOW_HASKELL__ >= 913
   -- fwrite-if-simplified-core requires a recent bug fix regarding GHCi loading
@@ -311,18 +305,12 @@ stackCradle fp = do
   pkgsWithComps <- liftIO $ catMaybes <$> mapM (Implicit.nestedPkg fp) pkgs
   let yaml = fp </> "stack.yaml"
   pure $ (,fp) $ case pkgsWithComps of
-    [] -> Config.Stack (mkStackType Nothing (Just yaml))
+    [] -> Config.Stack (Config.StackType Nothing (Just yaml) Nothing)
     ps -> Config.StackMulti mempty $ do
       Implicit.Package n cs <- ps
       c <- cs
       let (prefix, comp) = Implicit.stackComponent n c
-      pure (prefix, mkStackType (Just comp) (Just yaml))
-  where
-#if MIN_VERSION_hie_bios(0,20,0)
-    mkStackType a b = Config.StackType a b Nothing
-#else
-    mkStackType a b = Config.StackType a b
-#endif
+      pure (prefix, Config.StackType (Just comp) (Just yaml) Nothing)
 
 -- | By default, we generate a simple cabal cradle which is equivalent to the
 -- following hie.yaml:
@@ -334,11 +322,7 @@ stackCradle fp = do
 --
 -- Note, this only works reliable for reasonably modern cabal versions >= 3.2.
 simpleCabalCradle :: FilePath -> (Config.CradleTree a, FilePath)
-#if MIN_VERSION_hie_bios(0,20,0)
 simpleCabalCradle fp = (Config.Cabal $ Config.CabalType Nothing Nothing Nothing, fp)
-#else
-simpleCabalCradle fp = (Config.Cabal $ Config.CabalType Nothing Nothing, fp)
-#endif
 
 cabalExecutable :: MaybeT IO FilePath
 cabalExecutable = MaybeT $ findExecutable "cabal"

--- a/test/golden/T130b/T130b.ghc-1001.hdb-stdout
+++ b/test/golden/T130b/T130b.ghc-1001.hdb-stdout
@@ -1,4 +1,5 @@
-[1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[T130b-0.1.0.0-inplace-T130b]
+[1 of 3] Compiling Lib              ( <TEMPORARY-DIRECTORY>/lib/Lib.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Lib.gbc )[T130b-0.1.0.0-inplace]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[T130b-0.1.0.0-inplace-T130b]
 (hdb) MyType
 ()
 (hdb) Exiting...

--- a/test/golden/T130b/T130b.ghc-914.hdb-stdout
+++ b/test/golden/T130b/T130b.ghc-914.hdb-stdout
@@ -1,4 +1,5 @@
-[1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, interpreted )[T130b-0.1.0.0-inplace-T130b]
+[1 of 3] Compiling Lib              ( <TEMPORARY-DIRECTORY>/lib/Lib.hs, interpreted )[T130b-0.1.0.0-inplace]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, interpreted )[T130b-0.1.0.0-inplace-T130b]
 (hdb) MyType
 ()
 (hdb) Exiting...

--- a/test/golden/T135/hie.yaml
+++ b/test/golden/T135/hie.yaml
@@ -1,6 +1,5 @@
 cradle:
   cabal:
-    - path: "./mylib"
-      component: "lib:mylib"
+    #we want mylib to be an external package, so we don't list it in the cradle.
     - path: "./myapp/"
       component: "myapp"

--- a/test/golden/T237/hie.yaml
+++ b/test/golden/T237/hie.yaml
@@ -1,0 +1,5 @@
+cradle:
+  cabal:
+    components:
+      - path: "app/"
+        component: "exe:T237"

--- a/test/golden/T237b/T237.cabal
+++ b/test/golden/T237b/T237.cabal
@@ -1,0 +1,24 @@
+cabal-version:   3.14
+name:            T237
+version:         0.1.0.0
+license:         NONE
+author:          Rodrigo Mesquita
+maintainer:      rodrigo.m.mesquita@gmail.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyType
+    build-depends:    base
+    hs-source-dirs:   lib
+    default-language: Haskell2010
+
+executable T237
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base, T237, haskell-debugger-view
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/test/golden/T237b/T237.ghc-1001.hdb-stdout
+++ b/test/golden/T237b/T237.ghc-1001.hdb-stdout
@@ -1,0 +1,16 @@
+[1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[T237-0.1.0.0-inplace-T237]
+[;1m<TEMPORARY-DIRECTORY>/app/Main.hs:8:1: [;1m[35mwarning[0m[0m[;1m: [GHC-90177] [[;1m[35m-Worphans[0m[0m[;1m][0m[0m[;1m
+    Orphan class instance: instance DebugView MyType
+    Suggested fix:
+      Move the instance declaration to the module of the class or of the type, or
+      wrap the type with a newtype and declare the instance on the new type.[0m[0m
+[;1m[34m  |[0m[0m
+[;1m[34m8 |[0m[0m [;1m[35minstance DebugView MyType where[0m[0m
+[;1m[34m  |[0m[0m[;1m[35m ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...[0m[0m
+
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 1], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/app/Main.hs", startLine = 15, endLine = 15, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : MyType = _
+  value : MyType = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T237b/T237.ghc-914.hdb-stdout
+++ b/test/golden/T237b/T237.ghc-914.hdb-stdout
@@ -1,0 +1,16 @@
+[1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, interpreted )[T237-0.1.0.0-inplace-T237]
+[;1m<TEMPORARY-DIRECTORY>/app/Main.hs:8:1: [;1m[35mwarning[0m[0m[;1m: [GHC-90177] [[;1m[35m-Worphans[0m[0m[;1m][0m[0m[;1m
+    Orphan class instance: instance DebugView MyType
+    Suggested fix:
+      Move the instance declaration to the module of the class or of the type, or
+      wrap the type with a newtype and declare the instance on the new type.[0m[0m
+[;1m[34m  |[0m[0m
+[;1m[34m8 |[0m[0m [;1m[35minstance DebugView MyType where[0m[0m
+[;1m[34m  |[0m[0m[;1m[35m ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...[0m[0m
+
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 1], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/app/Main.hs", startLine = 15, endLine = 15, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : MyType = _
+  value : MyType = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T237b/T237.hdb-stdin
+++ b/test/golden/T237b/T237.hdb-stdin
@@ -1,0 +1,3 @@
+break app/Main.hs 15
+run
+variables

--- a/test/golden/T237b/T237b.ghc-1001.hdb-stdout
+++ b/test/golden/T237b/T237b.ghc-1001.hdb-stdout
@@ -1,0 +1,17 @@
+[1 of 3] Compiling MyType           ( <TEMPORARY-DIRECTORY>/lib/MyType.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/MyType.gbc )[T237-0.1.0.0-inplace]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[T237-0.1.0.0-inplace-T237]
+[;1m<TEMPORARY-DIRECTORY>/app/Main.hs:8:1: [;1m[35mwarning[0m[0m[;1m: [GHC-90177] [[;1m[35m-Worphans[0m[0m[;1m][0m[0m[;1m
+    Orphan class instance: instance DebugView MyType
+    Suggested fix:
+      Move the instance declaration to the module of the class or of the type, or
+      wrap the type with a newtype and declare the instance on the new type.[0m[0m
+[;1m[34m  |[0m[0m
+[;1m[34m8 |[0m[0m [;1m[35minstance DebugView MyType where[0m[0m
+[;1m[34m  |[0m[0m[;1m[35m ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...[0m[0m
+
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 1], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/app/Main.hs", startLine = 15, endLine = 15, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : MyType = _
+  value : MyType = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T237b/T237b.ghc-914.hdb-stdout
+++ b/test/golden/T237b/T237b.ghc-914.hdb-stdout
@@ -1,0 +1,17 @@
+[1 of 3] Compiling MyType           ( <TEMPORARY-DIRECTORY>/lib/MyType.hs, interpreted )[T237-0.1.0.0-inplace]
+[2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/app/Main.hs, interpreted )[T237-0.1.0.0-inplace-T237]
+[;1m<TEMPORARY-DIRECTORY>/app/Main.hs:8:1: [;1m[35mwarning[0m[0m[;1m: [GHC-90177] [[;1m[35m-Worphans[0m[0m[;1m][0m[0m[;1m
+    Orphan class instance: instance DebugView MyType
+    Suggested fix:
+      Move the instance declaration to the module of the class or of the type, or
+      wrap the type with a newtype and declare the instance on the new type.[0m[0m
+[;1m[34m  |[0m[0m
+[;1m[34m8 |[0m[0m [;1m[35minstance DebugView MyType where[0m[0m
+[;1m[34m  |[0m[0m[;1m[35m ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...[0m[0m
+
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 1], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/app/Main.hs", startLine = 15, endLine = 15, startCol = 3, endCol = 28}}
+(hdb) Stopped at breakpoint
+(hdb) _result : IO () = <fn> :: IO ()
+value : MyType = _
+  value : MyType = alpha:beta:gamma
+(hdb) Exiting...

--- a/test/golden/T237b/T237b.hdb-test
+++ b/test/golden/T237b/T237b.hdb-test
@@ -1,0 +1,1 @@
+$HDB -v0 app/Main.hs 2>&1 < T237.hdb-stdin || true

--- a/test/golden/T237b/app/Main.hs
+++ b/test/golden/T237b/app/Main.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import Data.List (intercalate)
+
+import GHC.Debugger.View.Class
+import MyType
+
+instance DebugView MyType where
+  debugValue (MyType xs) = simpleValue (intercalate ":" xs) False
+  debugFields _ = pure (VarFields [])
+
+main :: IO ()
+main = do
+  let value = mkValue
+  const (print value) value

--- a/test/golden/T237b/hie.yaml
+++ b/test/golden/T237b/hie.yaml
@@ -1,0 +1,3 @@
+#version with barebone cabal cradle, to make sure session structure is not important
+cradle:
+  cabal:

--- a/test/golden/T237b/lib/MyType.hs
+++ b/test/golden/T237b/lib/MyType.hs
@@ -1,0 +1,11 @@
+module MyType
+  ( MyType(..)
+  , mkValue
+  ) where
+
+newtype MyType = MyType [String]
+  deriving Show
+
+mkValue :: MyType
+mkValue = MyType ["alpha", "beta", "gamma"]
+{-# OPAQUE mkValue #-}

--- a/test/haskell/Test/Integration/MultiHomeUnit.hs
+++ b/test/haskell/Test/Integration/MultiHomeUnit.hs
@@ -6,6 +6,7 @@ module Test.Integration.MultiHomeUnit (multiHomeUnitTests) where
 import Test.DAP
 import Test.Tasty
 import Test.Tasty.HUnit
+import System.FilePath ((</>))
 #ifdef mingw32_HOST_OS
 import Test.Tasty.ExpectedFailure
 #endif
@@ -16,37 +17,38 @@ multiHomeUnitTests =
   ignoreTestBecause "Needs to be fixed for Windows (#199)" $
 #endif
   testGroup "DAP.Integration.MultiHomeUnit"
-    [ testCase "should run program to the end" runToTheEnd
-    , testCase "should stop at break-point in the same home unit" sameHomeUnitBP
-    , testCase "should stop at break-point in different home unit 1" otherHomeUnitBP1
-    , testCase "should stop at break-point in different home unit 2" otherHomeUnitBP2
+    [testGroup dirname [ testCase "should run program to the end" $ runToTheEnd dirname
+    , testCase "should stop at break-point in the same home unit" $ sameHomeUnitBP dirname
+    , testCase "should stop at break-point in different home unit 1" $ otherHomeUnitBP1 dirname
+    , testCase "should stop at break-point in different home unit 2" $ otherHomeUnitBP2 dirname
+    ] |
+    dirname <- ["cabal-mhu1","T38"]
     ]
-
-withCommonSetup :: (FilePath -> TestDAP ()) -> Assertion
-withCommonSetup test =
-  withTestDAPServer "test/integration/cabal-mhu1" [] $ \test_dir server ->
+withCommonSetup :: (FilePath -> TestDAP ()) -> String -> Assertion
+withCommonSetup test dirname =
+  withTestDAPServer ("test/integration" </> dirname) [] $ \test_dir server ->
     withTestDAPServerClient server $ do
       test test_dir
       disconnect
 
-runToTheEnd :: Assertion
+runToTheEnd :: String -> Assertion
 runToTheEnd = withCommonSetup $ \test_dir -> do
   let cfg = mkLaunchConfig test_dir "bar/app/Main.hs"
   runToEnd cfg
 
-sameHomeUnitBP :: Assertion
+sameHomeUnitBP :: String -> Assertion
 sameHomeUnitBP = withCommonSetup $ \test_dir -> do
   let cfg = mkLaunchConfig test_dir "bar/app/Main.hs"
   hitBreakpointWith cfg 8
 
-otherHomeUnitBP1 :: Assertion
+otherHomeUnitBP1 :: String -> Assertion
 otherHomeUnitBP1 = withCommonSetup $ \test_dir -> do
   -- Use bar/app/Main.hs as the entry file; set a breakpoint in a
   -- *different* home unit (bar/src/Bar.hs).
   let cfg = mkLaunchConfig test_dir "bar/app/Main.hs"
   hitBreakpointIn cfg "bar/src/Bar.hs" 8
 
-otherHomeUnitBP2 :: Assertion
+otherHomeUnitBP2 :: String -> Assertion
 otherHomeUnitBP2 = withCommonSetup $ \test_dir -> do
   let cfg = mkLaunchConfig test_dir "bar/app/Main.hs"
   hitBreakpointIn cfg "foo/src/Foo.hs" 6

--- a/test/integration/T107a/hie.yaml
+++ b/test/integration/T107a/hie.yaml
@@ -1,3 +1,3 @@
 cradle:
   cabal:
-    components: "exe:t3"
+    component: "exe:t3"

--- a/test/integration/T38/bar/app/Main.hs
+++ b/test/integration/T38/bar/app/Main.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import Bar
+import Foo
+
+main :: IO ()
+main = do
+  myFibonacciTest
+  print (fib 5)

--- a/test/integration/T38/bar/bar.cabal
+++ b/test/integration/T38/bar/bar.cabal
@@ -1,0 +1,20 @@
+cabal-version:      3.8
+name:               bar
+version:            0.1.0.0
+build-type:         Simple
+
+library
+    exposed-modules:  Bar
+    build-depends:
+        base,
+        foo,
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+executable bar-exe
+    main-is: app/Main.hs
+    build-depends:
+        base,
+        bar,
+        foo,
+    default-language: Haskell2010

--- a/test/integration/T38/bar/src/Bar.hs
+++ b/test/integration/T38/bar/src/Bar.hs
@@ -1,0 +1,10 @@
+module Bar where
+
+import Foo
+
+myFibonacciTest :: IO ()
+myFibonacciTest = do
+  print (fib 1)
+  print (fib 4)
+  print (fib 8)
+  print (fib 10)

--- a/test/integration/T38/cabal.project
+++ b/test/integration/T38/cabal.project
@@ -1,0 +1,3 @@
+packages:
+    ./foo
+    ./bar

--- a/test/integration/T38/foo/foo.cabal
+++ b/test/integration/T38/foo/foo.cabal
@@ -1,0 +1,10 @@
+cabal-version:      3.8
+name:               foo
+version:            0.1.0.0
+build-type:         Simple
+
+library
+    exposed-modules:  Foo
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/test/integration/T38/foo/src/Foo.hs
+++ b/test/integration/T38/foo/src/Foo.hs
@@ -1,0 +1,6 @@
+module Foo where
+
+fib :: Int -> Int
+fib n
+  | n <= 1 = 1
+  | otherwise = fib (n - 1) + fib (n - 2)


### PR DESCRIPTION
Still draft because we should wait for new release of hie-bios.

TODO:
- [x] fix #ifdef to support older hie-bios versions
- [x] fix failing golden tests. Adding hie.yaml cradles if needed or just accepting the change in interpreted modules