### PR TITLE
Trying out bytecode artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ vscode-extension/dist/
 vscode-extension/result
 dist-newstyle/
 cabal.project.local
+cabal-repl-bios/
+
+#ghci leftovers
+*.o
+*.hi
+*.gbc
 
 # Stack-related
 .stack-work

--- a/test/golden/artefacts/app/Main.hs
+++ b/test/golden/artefacts/app/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import MyLib
+
+main :: IO ()
+main = do
+  let x = "some var"
+  foo x
+  putStrLn x

--- a/test/golden/artefacts/artefacts.cabal
+++ b/test/golden/artefacts/artefacts.cabal
@@ -1,0 +1,26 @@
+cabal-version:   3.0
+name:            artefacts
+version:         0.1.0.0
+license:         NONE
+build-type:      Simple
+
+common extensions
+    default-language: GHC2021
+
+common ghc-options
+    ghc-options: -Wall -Widentities
+
+common rts-options
+    ghc-options: -rtsopts -threaded "-with-rtsopts=-N"
+library
+    exposed-modules: MyLib
+    hs-source-dirs: lib
+    build-depends: base
+executable e
+    import:           extensions
+    import:           ghc-options
+    import:           rts-options
+    main-is:          Main.hs
+    build-depends:    base, artefacts
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/test/golden/artefacts/cabal.project
+++ b/test/golden/artefacts/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+library-bytecode: True
+
+-- hdb sets -fbyte-code -fwrite-byte-code -fwrite-interface itself, but these might be relevant for debugging in ghci
+package artefacts
+  ghc-options: -fbyte-code-and-object-code -fwrite-byte-code -fwrite-interface 

--- a/test/golden/artefacts/hie.yaml
+++ b/test/golden/artefacts/hie.yaml
@@ -1,0 +1,6 @@
+cradle:
+  cabal:
+    - path: "./lib"
+      component: "lib:artefacts"
+    - path: "./app"
+      component: "exe:e"

--- a/test/golden/artefacts/lib/MyLib.hs
+++ b/test/golden/artefacts/lib/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib where
+
+foo :: String -> IO ()
+foo x = putStrLn (x ++ " got added")


### PR DESCRIPTION
added test/golden/artefacts with a simple exe depending on lib project to try them out.

We set these flags to have bytecode libs and .gbc files.
-- cabal.project
```
packages: .
library-bytecode: True
package artefacts
  ghc-options: -fbyte-code-and-object-code -fwrite-byte-code -fwrite-interface 
```
