### PR TITLE
Call initUniqSupply only once.

### DIFF
--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -54,7 +54,6 @@ import GHC.Runtime.Loader as GHC
 import GHC.Runtime.Context as GHCi
 import GHC.Types.Error
 import GHC.Types.SourceError
-import GHC.Types.Unique.Supply as GHC
 import GHC.Unit.Module.Graph
 import GHC.Unit.State
 import GHC.Unit.Module.ModSummary as GHC
@@ -185,6 +184,14 @@ data RunDebuggerSettings = RunDebuggerSettings
       }
 
 -- | Run a 'Debugger' action on a session constructed by a 'DebugRunner'
+--
+--  INVARIANT: The initUniqSupply has already been initialized.
+--
+--  Users of hdb-as-a-library will have to call `initUniqSupply` at their leisure,
+--  special care needed if they supply any loaded units/modules to us via the DebugRunner,
+--  as those will contain `Unique`s.
+--
+--  See Note [UniqueSupply is process global].
 runDebugger :: LogAction IO DebuggerLog -> DebugRunner Ghc a -> RunDebuggerSettings -> Debugger a -> IO a
 runDebugger l debugRunner conf action = annotateCallStackIO $ do
   debugRunner $ \ rootDir extraGhcArgs loadHomeUnit -> runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit action
@@ -310,9 +317,6 @@ runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action) = f
       -- Initialise plugins here because the plugin author might already expect this
       -- subsequent call to `getLogger` to be affected by a plugin.
       GHC.initializeSessionPlugins
-
-      GHC.getSessionDynFlags >>= \df -> liftIO $
-        GHC.initUniqSupply (GHC.initialUnique df) (GHC.uniqueIncrement df)
 
       loadHomeUnit
 
@@ -670,6 +674,30 @@ archive). This setting must definitely match the way in which the external
 interpreter was compiled (checked with `hostIsDynamic`, since the external
 interpreter and the debugger, while not necessarily the same process, are the
 same executable). Ditto for `iservConfProfiled` (with `hostIsProfiled`).
+
+Note [UniqueSupply is process global]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The generation of `Unique`s is controlled by two global pointers declared in the
+`ghc` package. The same two pointers are shared by all sessions, since the host
+ghc library is only loaded once.
+
+If the pointers get re-initialized while a session is active, that session might generate
+the same Unique again and we randomly get panics about identifiers out of scope or
+which do not match their expected type and so on.
+
+GHC calls the initialization function in main, with a comment saying it should be done
+before initializing plugins.
+
+The only safe time to initialize is if there are no existing Uniques that are still relevant,
+and since it's also cheap we do it right away in `main`, for the `cli` or `server` commands.
+
+Contrary to ghc itself, this means we do not honor the `initialUnique` and `uniqueIncrement`
+fields of DynFlags, but they seem to be there for testing anyway.
+
+Users of hdb-as-a-library, e.g. using runHDBServer, will have to do the initialization themselves,
+especially if they supply any loaded units/modules to us via the DebugRunner,
+as those will contain `Unique`s.
+
 -}
 --------------------------------------------------------------------------------
 

--- a/haskell-debugger/GHC/Debugger/Session.hs
+++ b/haskell-debugger/GHC/Debugger/Session.hs
@@ -39,6 +39,7 @@ module GHC.Debugger.Session (
   annotateCallStackGhc,
   lookupUnitPackageQualifier,
   fixHomeUnitsDynFlagsForIIDecl, getPgmI,
+  initUniqSupplyIO
   )
   where
 
@@ -102,6 +103,7 @@ import GHC.Types.SourceText (StringLiteral(..), SourceText (..))
 import GHC.Stack.Annotation
 import GHC.Stack (callStack)
 import GHC.Settings (ToolSettings(..))
+import qualified GHC.Types.Unique.Supply as GHC
 
 -- | Throws if package flags are unsatisfiable
 parseHomeUnitArguments :: GhcMonad m
@@ -663,6 +665,9 @@ addWay' w dflags0 =
                        (wayUnsetGeneralFlags platform w)
    in dflags3
 
+-- | See Note [ UniqSupply is process global ]
+initUniqSupplyIO :: IO ()
+initUniqSupplyIO = GHC.initUniqSupply 0 1
 
 -- ----------------------------------------------------------------------------
 -- Wrappers around GHC's odd behavior

--- a/hdb-dap/Development/Debug/Adapter/Server.hs
+++ b/hdb-dap/Development/Debug/Adapter/Server.hs
@@ -224,6 +224,15 @@ ack l rrr = case rrr.reverseRequestCommand of
       liftLogIO l <& DAPLaunchLog (WithSeverity (T.pack "RunInTerminal was successful") Info)
   _ -> pure ()
 
+-- | Starts a DAP server for haskell debugging.
+--
+--  INVARIANT: The initUniqSupply has already been initialized.
+--
+--  Users of hdb-as-a-library will have to call `initUniqSupply` at their leisure,
+--  special care needed if they supply any loaded units/modules to us via the `DebugRunner`,
+--  as those will contain `Unique`s.
+--
+--  See Note [UniqueSupply is process global].
 runHDBServer :: LogAction IO DAPLog -> DAPServerConf -> IO ()
 runHDBServer l servConf@DAPServerConf{ dapServerConfig = config } = do
   runDAPServerWithLogger (contramap DAPLibraryLog l) config

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -45,6 +45,7 @@ import GHC.Stack.Annotation (annotateCallStackIO)
 import GHC.Utils.Logger (defaultLogActionWithHandles)
 import Development.Debug.Session.Setup (hieDebugRunner)
 import GHC.Debugger.Debuggee (mkCliInterpreterSettings)
+import GHC.Debugger.Session (initUniqSupplyIO)
 
 #if MIN_VERSION_ghc(9,15,0)
 import GHC.Debugger.Runtime.Interpreter.Custom (dbgInterpCmdHandler)
@@ -71,6 +72,10 @@ main = do
       config <- getConfig port
       -- the same program invoked with `external-interpreter` serves as the external interpreter
       hdbProgram <- getExecutablePath
+
+      -- See Note [UniqueSupply is process global]
+      initUniqSupplyIO
+
       let servConf = DAPServerConf
             { getDebugRunner = hieDebugRunner
             , hdbProgram
@@ -84,6 +89,10 @@ main = do
           (ack l )
     HdbCLI{..} -> do
         setBacktraceMechanismState IPEBacktrace (not disableIpeBacktraces)
+
+        -- See Note [UniqueSupply is process global]
+        initUniqSupplyIO
+
         l <- mainLogger hdbOpts.verbosity stdout
         cliInterpSettings <- mkCliInterpreterSettings internalInterpreter debuggeeStdin
         let runConf = RunDebuggerSettings


### PR DESCRIPTION
I thought about setting up some way to still initialize on-demand but no more than once via an MVar, but then saw no real benefit since `initUniqSupply` doesn't actually construct anything to be passed around, it just pokes the values into the memory cells.

Settled for doing it in `main` then.