### PR TITLE
[Fix #273] Tag logs with session and thread Id + one more fix 

### DIFF
--- a/haskell-debugger.cabal
+++ b/haskell-debugger.cabal
@@ -206,6 +206,7 @@ library dap-server
         optparse-applicative >= 0.18 && < 0.20,
         uuid >= 1.3 && < 1.4,
         ghc-stack-annotations >=0.1 && <0.2,
+        monad-control >= 1.0 && < 1.1,
 
 executable hdb
     import:           warnings

--- a/haskell-debugger/GHC/Debugger/Debuggee.hs
+++ b/haskell-debugger/GHC/Debugger/Debuggee.hs
@@ -25,6 +25,8 @@ import Prelude hiding (mod)
 import Network.Socket hiding (Debug)
 import System.Process.Internals (mkProcessHandle)
 import Text.Read (readMaybe)
+import System.Environment (getExecutablePath)
+import Data.Text (Text)
 
 import GHC
 import GHC.Driver.Env as GHC
@@ -48,7 +50,6 @@ import GHC.Platform.Ways
 import GHC.Data.FastString.Env (emptyFsEnv)
 #endif
 import GHC.Debugger.Utils.Orphans () -- bring orphan instances to everything which uses `Debugger`
-import System.Environment (getExecutablePath)
 
 data InterpreterSettings = InterpreterSettings
       { interpreterFlags :: DynFlags -> DynFlags
@@ -212,6 +213,7 @@ mkCliInterpreterSettings internalInterpreter debuggeeStdin = do
 data DebuggerLog
   = DebuggerLog !Logger.Severity !DebuggerMessage
   | GHCLog !GHC.LogFlags !MessageClass !SrcSpan !SDoc
+  | DebuggerSessionLog !Logger.Severity !Text
 
 -- | A debugger log message
 data DebuggerMessage

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -33,6 +33,7 @@ import System.Posix.Signals
 #endif
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified GHC.Conc.Sync as C
 
 import GHC
 import GHC.Data.StringBuffer
@@ -79,6 +80,8 @@ import GHC.Unit.Home.Graph
 import GHC.Debugger.Utils.Orphans () -- bring orphan instances to everything which uses `Debugger`
 import System.Directory (getCurrentDirectory)
 import GHC.Debugger.Debuggee
+import GHC.Plugins (HasCallStack)
+import Data.Bifunctor
 
 -- | A debugger action.
 newtype Debugger a = Debugger { unDebugger :: ReaderT DebuggerState GHC.Ghc a }
@@ -244,8 +247,10 @@ withProjectDebugSession ProjectDebugSpec{ghcInvocation = ghcI, ..} k = do
     -- Discover the user-given flags and targets
     flagsAndTargets <- parseHomeUnitArguments absEntryFile componentDir units ghcInvocation dflags2 rootDir
 
+
+    let setVerbosity dflags = dflags {verbosity = verbosity dflags2}
     -- Setup HomeUnitGraph with debugee and interactiveGhcDebugger units
-    setupHomeUnitGraph (NonEmpty.toList flagsAndTargets)
+    setupHomeUnitGraph (map (first setVerbosity) $ NonEmpty.toList flagsAndTargets)
 
     debugee_mod_graph <- doDownsweep Nothing
 
@@ -318,7 +323,7 @@ runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action) = f
       -- subsequent call to `getLogger` to be affected by a plugin.
       GHC.initializeSessionPlugins
 
-      loadHomeUnit
+      preservingThreadLabel loadHomeUnit
 
       fixHomeUnitsDynFlagsForIIDecl
 
@@ -333,7 +338,9 @@ runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action) = f
 #ifndef DEBUG_WITH_GHC
       -- Find haskell-debugger-view in (deps of) home units, or load one from
       -- in-memory sources.
-      (hdv_uid, loadedBuiltinModNames) <- findOrLoadHaskellDebuggerView l buildWays
+      (hdv_uid, loadedBuiltinModNames) <- do
+        preservingThreadLabel $
+          findOrLoadHaskellDebuggerView l buildWays
 #else
       let hdv_uid = hsDebuggerViewInMemoryUnitId
       let loadedBuiltinModNames = [] :: [ModuleName]
@@ -394,6 +401,18 @@ runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action) = f
             (if loadedBuiltinModNames == []
               then Nothing
               else Just hdv_uid)
+
+preservingThreadLabel :: HasCallStack => Ghc a -> Ghc a
+preservingThreadLabel m = do
+  thId <- liftIO $ myThreadId
+  mlbl <- liftIO $ C.threadLabel thId
+  case mlbl of
+    Nothing -> m
+    Just lbl -> do
+      annotateCallStackGhc $ do
+        x <- m
+        liftIO $ C.labelThread thId lbl
+        pure x
 
 
 findOrLoadHaskellDebuggerView :: LogAction IO DebuggerLog

--- a/haskell-debugger/GHC/Debugger/Run.hs
+++ b/haskell-debugger/GHC/Debugger/Run.hs
@@ -81,10 +81,11 @@ debugExecution entryFile entry args = do
     evalModule = mkModule (RealUnit (Definite unitIdOfEntryFile))
                                          (moduleName modOfEntryFile)
 
-  logSDoc Logger.Debug $ "Eval Module Context:" <+> ppr evalModule
+  logSDoc Logger.Debug $ "Eval inputs: " <+> text (show (entryFile,entry,args))
+  logSDoc Logger.Debug $ "Eval Module Context:" <+> withPprStyle (PprDump reallyAlwaysQualify) (ppr evalModule) <+> ppr (ms_location modSummaryOfEntryFile) <+> text (ms_hspp_file modSummaryOfEntryFile)
 
   old_context <- GHC.getContext
-  GHC.setContext [GHC.IIModule evalModule]
+  GHC.setContext [IIModule evalModule]
 
   (entryExp, exOpts) <- case entry of
     MainEntry nm -> do
@@ -101,9 +102,17 @@ debugExecution entryFile entry args = do
       -- be "\"some\"" "\"things\"".
       return (fn ++ " " ++ unwords args, GHC.execOptions)
 
+  logSDoc Logger.Debug "Compiled wrapper."
+
   exec_res <- GHC.execStmt entryExp exOpts
-  GHC.setContext old_context -- restore context after running `main`
-  handleExecResult exec_res
+
+  logSDoc Logger.Debug $ "Executed entryExp: " <+> text entryExp
+
+  GHC.setContext old_context
+
+  res <- handleExecResult exec_res
+  logSDoc Logger.Debug $ "Computed EvalResult."
+  pure res
   where
     -- It's not ideal to duplicate these two functions from ghci, but its unclear where they would better live. Perhaps next to compileParsedExprRemote? The issue is run
     mkEvalWrapper :: GhcMonad m => String -> [String] -> m ForeignHValue

--- a/hdb-dap/Development/Debug/Adapter.hs
+++ b/hdb-dap/Development/Debug/Adapter.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE LambdaCase #-}
 module Development.Debug.Adapter where
 
-import Control.Concurrent.MVar
+import Control.Concurrent
+import Control.Monad (void)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Trans.Control (liftBaseDiscard)
 import qualified Data.IntSet as IS
 import qualified Data.Map as Map
 import qualified Data.IntMap as IM
@@ -48,6 +52,12 @@ data VariablesIx = VariablesIx StackFrameIx D.VariableReference
 
 instance MonadFail DebugAdaptor where
   fail a = sendError (ErrorMessage (T.pack a)) Nothing
+
+safeDestroyDebugSession :: Adaptor app request ()
+safeDestroyDebugSession = void $ do
+  -- Without forkIO we might kill ourselves first and not kill anything else.
+  liftBaseDiscard forkIO $
+    destroyDebugSession `catchError` \ e -> liftIO $ putStrLn ("safeDestroyDebugSession: ignoring missing session: " ++ show e)
 
 --------------------------------------------------------------------------------
 -- * Utilities

--- a/hdb-dap/Development/Debug/Adapter/DAPDebuggee.hs
+++ b/hdb-dap/Development/Debug/Adapter/DAPDebuggee.hs
@@ -160,7 +160,7 @@ internalInTerminalDAPD l hdbProg = do
 --------------------------------------------------------------------------------
 -- * Logging
 --------------------------------------------------------------------------------
-
+type SessionId = T.Text
 data DAPSessionLog
   = DAPSessionSetupLog (WithSeverity SessionSetupLog)
   | DAPDebuggerLog Debugger.DebuggerLog

--- a/hdb-dap/Development/Debug/Adapter/Exit.hs
+++ b/hdb-dap/Development/Debug/Adapter/Exit.hs
@@ -22,8 +22,6 @@
 -- * @'destroyDebugSession'@ kills all threads started for this session with @'registerNewDebugSession'@.
 module Development.Debug.Adapter.Exit where
 
-import Control.Monad.Except
-import Control.Monad.IO.Class
 import DAP
 import Development.Debug.Adapter
 
@@ -43,5 +41,5 @@ commandDisconnect :: DebugAdaptor ()
 commandDisconnect = do
   -- kills debugger GHC session (which handles stopping the debuggee ext-interp too)
   -- ignore error if session has already been destroyed (e.g. client sends disconnect after terminate)
-  destroyDebugSession `catchError` \ e -> liftIO $ putStrLn ("terminateSessionCleanly: ignoring missing session: " ++ show e)
+  safeDestroyDebugSession
   sendDisconnectResponse

--- a/hdb-dap/Development/Debug/Adapter/Init.hs
+++ b/hdb-dap/Development/Debug/Adapter/Init.hs
@@ -22,7 +22,7 @@ import GHC.Conc.Sync (labelThread)
 import GHC.IO.Handle
 import qualified Data.Text as T
 import qualified System.Process as P
-import Control.Exception (displayExceptionWithInfo)
+import Control.Exception (displayExceptionWithInfo, ExceptionWithContext (ExceptionWithContext), AsyncException (..))
 import Control.Monad (when)
 import Control.Monad.Except
 import Control.Monad.Trans
@@ -168,7 +168,7 @@ initDebugger l0 servConf interpChoice
         absEntryFile = projectRoot /> entryFile
         daState = DAS{entryFile=absEntryFile,waitForDebuggee = dapdWaitForDebuggee dapd,..}
 
-      registerNewDebugSession sessionId daState $
+      registerNewDebugSession sessionId daState $ map (destroyDebugSessionOnException l) $
         [ \withAdaptor -> do
             -- The info here is already taken into account in debugRunner.
             let GhcInvocation libdir units args = ghcInvocation
@@ -186,6 +186,22 @@ initDebugger l0 servConf interpChoice
         dapdThreads dapd
 
       dapdAfterRegister dapd
+
+destroyDebugSessionOnException :: LogAction IO DAPSessionLog
+  -> ((Adaptor a r () -> IO ()) -> IO ())
+  -> (Adaptor a r () -> IO ())
+  -> IO ()
+destroyDebugSessionOnException l k withAdaptor = do
+  k withAdaptor
+    `catchNoPropagate` \ x@(ExceptionWithContext _ctx e) -> do
+      l <& DAPDebuggerLog (DebuggerSessionLog Debug $ (T.pack $ displayExceptionWithInfo (toException x)))
+      case fromException e of
+        -- TODO: would be better if destroyDebugSession from dap sent a custom exception, so we are sure we don't have to propagate it to the other threads.
+        Just ThreadKilled -> return ()
+        _ -> do
+          withAdaptor $ do
+            sendTerminatedEvent (TerminatedEvent False)
+            safeDestroyDebugSession
 
 initDAPDebuggee
   :: LogAction IO DAPSessionLog

--- a/hdb-dap/Development/Debug/Adapter/Init.hs
+++ b/hdb-dap/Development/Debug/Adapter/Init.hs
@@ -23,6 +23,7 @@ import GHC.IO.Handle
 import qualified Data.Text as T
 import qualified System.Process as P
 import Control.Exception (displayExceptionWithInfo)
+import Control.Monad (when)
 import Control.Monad.Except
 import Control.Monad.Trans
 import Data.Function
@@ -99,9 +100,9 @@ data InterpreterChoice = InterpreterChoice { runInTerminal :: Bool, internal :: 
 -- | Initialize debugger
 --
 -- Returns @()@ if successful, throws @InitFailed@ otherwise
-initDebugger :: LogAction IO DAPSessionLog -> DAPServerConf -> InterpreterChoice
+initDebugger :: LogAction IO (T.Text,DAPSessionLog) -> DAPServerConf -> InterpreterChoice
              -> LaunchArgs -> DebugAdaptor ()
-initDebugger l servConf interpChoice
+initDebugger l0 servConf interpChoice
                LaunchArgs{ __sessionId
                          , projectRoot = givenRoot
                          , entryFile = entryFileMaybe
@@ -118,6 +119,9 @@ initDebugger l servConf interpChoice
     Just ef -> pure ef
 
   projectRoot <- liftIO $ mkAbsolute <$> maybe getCurrentDirectory makeAbsolute givenRoot
+
+  sessionId <- liftIO $ maybe (T.show <$> UUID.nextRandom) (pure . T.pack) __sessionId
+  let l = contramap (sessionId,) l0
 
   -- Create a pipe to which messages to send to the DAP console are written and read.
   -- todo: This could just be a Haskell channel now...
@@ -163,9 +167,6 @@ initDebugger l servConf interpChoice
           }
         absEntryFile = projectRoot /> entryFile
         daState = DAS{entryFile=absEntryFile,waitForDebuggee = dapdWaitForDebuggee dapd,..}
-
-      -- TODO: is nextRandom threadsafe?
-      sessionId <- liftIO $ maybe (("debug-session:" <>) . T.show <$> UUID.nextRandom) (pure . T.pack) __sessionId
 
       registerNewDebugSession sessionId daState $
         [ \withAdaptor -> do
@@ -217,6 +218,9 @@ debuggerThread :: LogAction IO Debugger.DebuggerLog
                -> MVar D.Response -- ^ Write reponses
                -> IO ()
 debuggerThread l debugRunner runConf requests replies = do
+  liftIO $ do
+    tid <- myThreadId
+    labelThread tid "Main Debugger Thread (before runDebugger)"
   Debugger.runDebugger l debugRunner runConf $ do
     liftIO $ do
       tid <- myThreadId
@@ -265,10 +269,11 @@ createDebuggerLogger l dapLogger writeDAPOutput = do
     contramap DAPDebuggerLog l <>
     -- (2) and (3) (log relevant output to DAP handle)
       LogAction (\case
-        Debugger.DebuggerLog sev msg
-          | sev >= Info -> do
+        Debugger.DebuggerLog sev msg ->
+          when (sev >= Info) $
             dapLogger <& T.pack (show msg)
         Debugger.GHCLog logflags msg_class srcSpan msg ->
           defaultLogActionWithHandles writeDAPOutput writeDAPOutput logflags msg_class srcSpan msg
-        _ -> pure () -- don't log other messages, already logged to (1)
+        -- don't log other messages, already logged to (1)
+        Debugger.DebuggerSessionLog{} -> pure ()
         )

--- a/hdb-dap/Development/Debug/Adapter/Server.hs
+++ b/hdb-dap/Development/Debug/Adapter/Server.hs
@@ -15,6 +15,8 @@ import Data.Maybe
 import Text.Read
 import Control.Monad
 import Control.Monad.IO.Class
+import Control.Concurrent (ThreadId, myThreadId)
+import GHC.Conc.Sync (threadLabel)
 
 import DAP
 
@@ -40,6 +42,7 @@ import Development.Debug.Adapter
 
 import qualified GHC.Utils.Logger as GHC
 import GHC.Debugger.Debuggee (DebuggerLog(..))
+import qualified GHC.Plugins as GHC
 
 
 -------------------------------------------------------------------------
@@ -143,7 +146,7 @@ talk l servConf prefer_internal_interpreter = \ case
     let runInTerminal = fromMaybe False $ supportsRunInTerminalRequest =<< clientCaps
 #endif
 
-    initDebugger (contramap DAPSessionLog l) servConf
+    initDebugger (cmapM (\ (sId,x) -> DAPSessionLog sId <$> myThreadId <*> pure x) l) servConf
       InterpreterChoice {runInTerminal, internal = prefer_internal_interpreter}
       launch_args
 
@@ -244,40 +247,64 @@ runHDBServer l servConf@DAPServerConf{ dapServerConfig = config } = do
 --------------------------------------------------------------------------------
 
 data DAPLog
-  = DAPSessionLog DAPSessionLog
+  = DAPSessionLog !SessionId !ThreadId DAPSessionLog
   | DAPLaunchLog (WithSeverity T.Text)
   | DAPLibraryLog DAP.DAPLog
 
 logSessionLog :: Show a => LogAction IO Text -> Severity -> WithSeverity a -> IO ()
 logSessionLog l threshold (WithSeverity msg sev)
       | sev >= threshold =
-        cmapM renderWithTimestamp l <& (renderSeverity sev <> T.pack (show msg))
+        l <& (renderSeverity sev <> T.pack (show msg))
       | otherwise = pure ()
 
 logDebuggerLog :: GHC.LogAction -> LogAction IO Text -> Severity -> DebuggerLog -> IO ()
 logDebuggerLog logGhcLog l threshold = \case
-      DebuggerLog sev msg
-        | sev >= threshold ->
-          cmapM renderWithTimestamp l <&
+      DebuggerLog sev msg ->
+        when (sev >= threshold) $
+          l <&
             (renderSeverity sev <> T.pack (show msg))
       GHCLog logflags msg_class srcSpan msg ->
         logGhcLog logflags msg_class srcSpan msg
-      _ -> pure ()
+      DebuggerSessionLog sev msg ->
+        when (sev >= threshold) $
+          l <&
+            (renderSeverity sev <> T.pack (show msg))
 
 defaultLog :: LogAction IO Text -> Severity -> WithSeverity Text -> IO ()
 defaultLog l threshold (WithSeverity msg sev)
       | sev >= threshold =
-        cmapM renderWithTimestamp l <& (renderSeverity sev <> msg)
+        l <& (renderSeverity sev <> msg)
       | otherwise = pure ()
+
+renderSessionId :: Text -> Text
+renderSessionId sId = "[SESSID=" <> sId <> "]"
+
+renderThreadLabel :: ThreadId -> IO Text
+renderThreadLabel thId = do
+  let dropThreadId t = fromMaybe t $ T.stripPrefix "ThreadId " t
+  lbl <- maybe (dropThreadId $ T.show thId) T.pack <$> threadLabel thId
+  pure $ "[THREAD=" <> lbl <> "]"
+
+renderWithDAPPrefix :: Text -> ThreadId -> Text -> IO Text
+renderWithDAPPrefix sessionId thId msg = do
+  lbl <- renderThreadLabel thId
+  renderWithTimestamp (renderSessionId sessionId <> lbl <> msg)
 
 -- | Main log action for the HDB DAP server. Takes a log action for ghc messages, a
 -- Text log action for everything else, and a severity threshold.
 logDAPLog :: GHC.LogAction -> LogAction IO Text -> Severity -> LogAction IO DAPLog
 logDAPLog logGhcLog l threshold = LogAction $ \case
-      DAPSessionLog (DAPSessionSetupLog sessionLog)       -> logSessionLog l threshold sessionLog
-      DAPSessionLog (DAPDebuggerLog debuggerLog)          -> logDebuggerLog logGhcLog l threshold debuggerLog
-      DAPSessionLog (RunProxyServerLog sev_msg) -> defaultLog l threshold sev_msg
-      DAPLaunchLog sev_msg      -> defaultLog l threshold sev_msg
+      DAPSessionLog sessionId threadId msg -> do
+        let l1 = cmapM (renderWithDAPPrefix sessionId threadId) l
+            logGhcLog1 f mc sp sdoc = do
+              prefix <- renderWithDAPPrefix sessionId threadId ""
+              logGhcLog f mc sp (GHC.text (T.unpack prefix) GHC.<> sdoc)
+
+        case msg of
+          (DAPSessionSetupLog sessionLog)       -> logSessionLog l1 threshold sessionLog
+          (DAPDebuggerLog debuggerLog)          -> logDebuggerLog logGhcLog1 l1 threshold debuggerLog
+          (RunProxyServerLog sev_msg) -> defaultLog l1 threshold sev_msg
+      DAPLaunchLog sev_msg      -> defaultLog (cmapM renderWithTimestamp l) threshold sev_msg
       DAPLibraryLog t | convert t.severity >= threshold ->
         l <& DAP.renderDAPLog t
         | otherwise -> pure ()


### PR DESCRIPTION
I had been making a few modifications while debugging the UniqueSupply bug, these should be kept.

- `DAPSessionLog` logs now have [SESSID=...][THREAD=<label or number>] tags.
- `DAPLog` logs only have the port, but one can relate it to the SESSID

- I was under the impression that `dap` would tear down the whole session on uncaught exceptions from any of the session threads. Instead it appears to only close the connection. No big deal though, we can have whichever crashed fork a thread to kill the rest.

