### PR TITLE
Assorted fixes for 10.2 for VSCode to work at all, and full testsuite to pass

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,13 +7,6 @@ source-repository-package
     location: https://github.com/haskell/hie-bios
     tag: 96ceadb49af86f77248f12dc3ae77d0dbb1457d5
 
--- See issue https://gitlab.haskell.org/ghc/ghc/-/issues/27419
--- We can remove this, once the upstream issue is solved and the
--- nightly GHC version is updated to include the fix from #27419.
-if impl(ghc <10.1)
-    package *
-        ghc-options: -finfo-table-map
-
 if !os(windows)
     package *
         -- Speeds up a bit

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,11 @@ packages: . haskell-debugger-view
 
 allow-newer: ghc-bignum,containers,time,ghc,base,template-haskell
 
+source-repository-package
+    type: git
+    location: https://github.com/haskell/hie-bios
+    tag: 96ceadb49af86f77248f12dc3ae77d0dbb1457d5
+
 -- See issue https://gitlab.haskell.org/ghc/ghc/-/issues/27419
 -- We can remove this, once the upstream issue is solved and the
 -- nightly GHC version is updated to include the fix from #27419.

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -742,11 +742,17 @@ doDownsweep reuse_mg = do
 #endif
       [] False
   when (not $ null errs_base) $ do
+    -- Print the errors to the user, rather than just throwing. When using DAP,
+    -- outputting to the logger the error is what displays it in the "Debug
+    -- Console" rather than "Output" DAP log.
+    logger <- getLogger
+    dflags <- hsc_dflags <$> getSession
+    let ghc_errs = fmap GhcDriverMessage (unionManyMessages errs_base)
+    liftIO $ printMessages logger (initPrintConfig dflags) (initDiagOpts dflags) ghc_errs
 #if MIN_VERSION_ghc(9,15,0)
-    sec <- initSourceErrorContext . hsc_dflags <$> getSession
-    throwErrors sec (fmap GhcDriverMessage (unionManyMessages errs_base))
+    throwErrors (initSourceErrorContext dflags) ghc_errs
 #else
-    throwErrors (fmap GhcDriverMessage (unionManyMessages errs_base))
+    throwErrors ghc_errs
 #endif
   return mod_graph
 

--- a/haskell-debugger/GHC/Debugger/Monad.hs
+++ b/haskell-debugger/GHC/Debugger/Monad.hs
@@ -267,7 +267,9 @@ runDebuggerAction :: forall a. LogAction IO DebuggerLog
   -> Ghc () -- ^ load home units action
   -> Debugger a
   -> Ghc a
-runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action) = flip MC.finally cleanupInterp $ -- See Note [Shutting down the external interpreter]
+runDebuggerAction l rootDir extraGhcArgs conf loadHomeUnit (Debugger action)
+  = flip MC.finally cleanupInterp $
+          -- See Note [Shutting down the external interpreter]
   do
   dflags0 <- GHC.getSessionDynFlags
   let dflags1 = dflags0
@@ -699,7 +701,7 @@ interpreter and the debugger, while not necessarily the same process, are the
 same executable). Ditto for `iservConfProfiled` (with `hostIsProfiled`).
 
 Note [UniqueSupply is process global]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The generation of `Unique`s is controlled by two global pointers declared in the
 `ghc` package. The same two pointers are shared by all sessions, since the host
 ghc library is only loaded once.

--- a/haskell-debugger/GHC/Debugger/Session.hs
+++ b/haskell-debugger/GHC/Debugger/Session.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DerivingStrategies, CPP, RecordWildCards #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Initialise the GHC session for one or more home units.
 --
@@ -60,6 +63,7 @@ import qualified Data.Map as Map
 import Data.IORef (newIORef)
 #endif
 import qualified Data.List as L
+import qualified Data.List as List
 import qualified Data.Containers.ListUtils as ListUtils
 import GHC.ResponseFile (expandResponse)
 import HIE.Bios.Environment as HIE
@@ -78,7 +82,7 @@ import GHC.Unit.Home.Graph
 import GHC.Unit.Home.PackageTable
 import GHC.Unit.Env
 #if MIN_VERSION_ghc(10,1,0)
-import GHC.Unit.External.Index (UnitIndexCache, initUnitIndexCache)
+import GHC.Unit.External.Index (UnitIndexCache)
 #endif
 import GHC.Unit.Types
 import qualified GHC.Unit.State                        as State
@@ -114,6 +118,7 @@ import GHC.Stack.Annotation
 import GHC.Stack (callStack)
 import GHC.Settings (ToolSettings(..))
 import qualified GHC.Types.Unique.Supply as GHC
+import Data.Containers.ListUtils (nubOrd)
 
 -- | Throws if package flags are unsatisfiable
 parseHomeUnitArguments :: GhcMonad m
@@ -184,17 +189,14 @@ setupHomeUnitGraph flagsAndTargets = do
 
 -- | Set up the 'HomeUnitGraph' with empty 'HomeUnitEnv's.
 -- The first 'DynFlags' are the 'DynFlags' for the interactive session.
-createHomeUnitGraph :: GHC.Logger -> [DynFlags] -> IO HomeUnitGraph
-createHomeUnitGraph logger unitDflags = do
+createHomeUnitGraph :: GHC.Logger -> UnitEnv -> [DynFlags] -> IO HomeUnitGraph
+createHomeUnitGraph logger _uenv unitDflags = do
   let home_units = Set.fromList $ map homeUnitId_ unitDflags
 
-#if MIN_VERSION_ghc(10,1,0)
-  uic <- initUnitIndexCache
-#endif
   unitEnvList <- flip traverse unitDflags $ \ dflags -> do
     let uid = homeUnitId_ dflags
 #if MIN_VERSION_ghc(10,1,0)
-    hue <- setupNewHomeUnitEnv home_units logger dflags uic
+    hue <- setupNewHomeUnitEnv home_units logger dflags (ue_uic _uenv)
 #else
     hue <- setupNewHomeUnitEnv home_units logger dflags Nothing
 #endif
@@ -220,17 +222,21 @@ fixHomeUnitsDynFlagsForIIDecl = do
 
 -- | The first argument should contain the home units the new @HomeUnitEnv@ depends on (@allUnits (hsc_HUG env)@ is always safe to give).
 --   The actual dependencies are specified by the @packageFlags@ in the @DynFlags@ argument.
+setupNewHomeUnitEnv
+  :: Set UnitId -> GHC.Logger -> DynFlags
 #if MIN_VERSION_ghc(10,1,0)
-setupNewHomeUnitEnv :: Set UnitId -> GHC.Logger -> DynFlags -> UnitIndexCache -> IO HomeUnitEnv
-setupNewHomeUnitEnv hug_keys logger dflags uic = do
+  -> UnitIndexCache
+#else
+  -> Maybe [GHC.UnitDatabase UnitId]
+#endif
+  -> IO HomeUnitEnv
+setupNewHomeUnitEnv hug_keys logger dflags cached_dbs = do
   emptyHpt <- emptyHomePackageTable
-  (unit_state,home_unit,mconstants) <- State.initUnits logger dflags uic hug_keys
+#if MIN_VERSION_ghc(10,1,0)
+  (unit_state,home_unit,mconstants) <- State.initUnits logger dflags cached_dbs hug_keys
   updated_dflags <- GHC.updatePlatformConstants dflags mconstants
   pure $ mkHomeUnitEnv unit_state updated_dflags emptyHpt (Just home_unit)
 #else
-setupNewHomeUnitEnv :: Set UnitId -> GHC.Logger -> DynFlags -> Maybe [GHC.UnitDatabase UnitId] -> IO HomeUnitEnv
-setupNewHomeUnitEnv hug_keys logger dflags cached_dbs = do
-  emptyHpt <- emptyHomePackageTable
   (dbs,unit_state,home_unit,mconstants) <- State.initUnits logger dflags cached_dbs hug_keys
   updated_dflags <- GHC.updatePlatformConstants dflags mconstants
   pure $ mkHomeUnitEnv unit_state (Just dbs) updated_dflags emptyHpt (Just home_unit)
@@ -243,7 +249,7 @@ setupNewHomeUnitEnv hug_keys logger dflags cached_dbs = do
 initHomeUnitEnv :: [DynFlags] -> HscEnv -> IO HscEnv
 initHomeUnitEnv unitDflags env = do
 
-  initial_home_graph <- createHomeUnitGraph (hsc_logger env) unitDflags
+  initial_home_graph <- createHomeUnitGraph (hsc_logger env) (hsc_unit_env env) unitDflags
 
   -- We need one of the units to be the `ue_currentUnit`: by default it's "main", but we don't create such a unit and Ghc panics.
   addInteractiveGhcDebuggerUnit (Set.toList . allUnits $ initial_home_graph) $ hscUpdateHUG (const initial_home_graph) env
@@ -273,6 +279,8 @@ addInteractiveGhcDebuggerUnit exposed env = do
             , uid /= interactiveGhcDebuggerUnitId
             -- TODO: other uids to filter?
             ]
+        , packageDBFlags = concatPackageDbStacksUsingLongestCommonPrefix $
+            (fmap (packageDBFlags . homeUnitEnv_dflags) (Foldable.toList initial_home_graph))
         }
 
 #if MIN_VERSION_ghc(10,1,0)
@@ -293,6 +301,20 @@ addInteractiveGhcDebuggerUnit exposed env = do
         , ue_namever         = GHC.ghcNameVersion interactiveDFlags
         }
   pure $ hscSetFlags interactiveDFlags $ hscSetUnitEnv unit_env env
+  where
+    -- inlined from GHCi. Patiently waiting for a nice Dev UX to units and flags...
+    concatPackageDbStacksUsingLongestCommonPrefix :: Ord a => [[a]] -> [a]
+    concatPackageDbStacksUsingLongestCommonPrefix (fmap reverse -> stacks) =
+      let
+        -- O (m * n)
+        -- m ... Number of PackageDBFlag stacks
+        -- n ... Size of the stacks
+        longestCommonPrefix =
+          map List.head . List.takeWhile ((List.all . (==) . List.head) <*> List.tail) . List.transpose
+        prefix =
+          longestCommonPrefix stacks
+      in
+        prefix ++ nubOrd (concatMap (List.drop (length prefix)) stacks)
 
 -- | Sets the units from the @ModuleGraph@ as the exposed ones for @InteractiveGhcDebuggerUnit@.
 --
@@ -773,3 +795,8 @@ dropEnd i xs
     | otherwise = f xs (drop i xs)
     where f (a:as) (_:bs) = a : f as bs
           f _ _ = []
+
+#if !MIN_VERSION_ghc(10,1,0)
+deriving instance Ord PkgDbRef
+deriving instance Ord PackageDBFlag
+#endif

--- a/haskell-debugger/GHC/Debugger/Session/Builtin.hs
+++ b/haskell-debugger/GHC/Debugger/Session/Builtin.hs
@@ -20,9 +20,11 @@ module GHC.Debugger.Session.Builtin
 
 import Data.FileEmbed
 import Data.Function
-import Data.Maybe
 import Data.Time
+#if !MIN_VERSION_ghc(10,1,0)
+import Data.Maybe
 import qualified Data.Foldable as Foldable
+#endif
 
 import GHC
 import GHC.Unit

--- a/haskell-debugger/GHC/Debugger/Session/Builtin.hs
+++ b/haskell-debugger/GHC/Debugger/Session/Builtin.hs
@@ -112,6 +112,11 @@ addInMemoryHsDebuggerViewUnit base_uids initialDynFlags = do
         , thisPackageName = Just "haskell-debugger-view"
         }
         & setGeneralFlag' Opt_HideAllPackages
+#if MIN_VERSION_ghc(9,14,2)
+        -- In memory modules should not write .hi nor .gbc files.
+        & flip gopt_unset Opt_WriteByteCode
+        & flip gopt_unset Opt_WriteInterface
+#endif
   hsc_env <- getSession
 #if MIN_VERSION_ghc(10,1,0)
   (unit_state,home_unit,mconstants) <- liftIO $ State.initUnits (hsc_logger hsc_env) imhdv_dflags (hscUIC hsc_env) $ HUG.allUnits $ hsc_HUG $ hsc_env

--- a/hdb-dap/Development/Debug/Adapter/Server.hs
+++ b/hdb-dap/Development/Debug/Adapter/Server.hs
@@ -268,7 +268,7 @@ logDebuggerLog logGhcLog l threshold = \case
       DebuggerSessionLog sev msg ->
         when (sev >= threshold) $
           l <&
-            (renderSeverity sev <> T.pack (show msg))
+            (renderSeverity sev <> msg)
 
 defaultLog :: LogAction IO Text -> Severity -> WithSeverity Text -> IO ()
 defaultLog l threshold (WithSeverity msg sev)

--- a/hdb/Development/Debug/Options.hs
+++ b/hdb/Development/Debug/Options.hs
@@ -69,10 +69,12 @@ data HdbOptions
   | HdbExternalInterpreter
       { writeFd :: Int
       , readFd  :: Int
+      , verbosity :: Severity
       }
 
   -- | Launch the custom-for-the-debugger external interpreter and connect it
   -- to the debugger through a TCP socket.
   | HdbExternalInterpreterPort
       { port :: Int
+      , verbosity :: Severity
       }

--- a/hdb/Development/Debug/Options/Parser.hs
+++ b/hdb/Development/Debug/Options/Parser.hs
@@ -106,6 +106,7 @@ extInterpParser =
          <> short 'p'
          <> metavar "PORT"
          <> help "port on which the external interpreter should connect to the debugger" )
+        <*> verbosityParser Error
   <|> HdbExternalInterpreter
         <$> argument auto
           ( metavar "WRITE_FD"
@@ -113,6 +114,7 @@ extInterpParser =
         <*> argument auto
           ( metavar "READ_FD"
          <> help "external interpreter read file descriptor" )
+        <*> verbosityParser Error
 
 -- | Combined parser for HdbOptions
 hdbOptionsParser :: Parser HdbOptions

--- a/hdb/Main.hs
+++ b/hdb/Main.hs
@@ -64,7 +64,7 @@ main = do
          -- Special case to detect --external-interpreter in the third
          -- position. If we could specify -opti options to put *before* the
          -- descriptors we could get rid of this.
-         pure (HdbExternalInterpreter (read writeFd) (read readFd))
+         pure (HdbExternalInterpreter (read writeFd) (read readFd) Error)
     _ -> parseHdbOptions
   case hdbOpts of
     HdbDAPServer{port, internalInterpreter, disableIpeBacktraces} -> do
@@ -108,20 +108,20 @@ main = do
     HdbExternalInterpreter{writeFd, readFd} -> do
       inh  <- GHCi.readGhcHandle (show readFd)
       outh <- GHCi.readGhcHandle (show writeFd)
-      runExternalInterpreterServer inh outh
+      runExternalInterpreterServer inh outh hdbOpts.verbosity
     HdbExternalInterpreterPort{port} -> do
       pid <- getCurrentPid
       withExternalInterpreterPort (fromIntegral port) $ \h -> do
         hPutStrLn h (show pid)
         hFlush h
-        runExternalInterpreterServer h h
+        runExternalInterpreterServer h h hdbOpts.verbosity
   where
-    runExternalInterpreterServer inh outh = do
+    runExternalInterpreterServer inh outh verbosity = do
       GHCi.installSignalHandlers
       pipe <- GHCi.mkPipeFromHandles inh outh
-      let verbose = False
-#if MIN_VERSION_ghc(9,15,0)
-      uninterruptibleMask $ \restore ->
+      let verbose = verbosity <= Info -- Debug || Info
+#if MIN_VERSION_ghc(9,14,2)
+      uninterruptibleMask $ \restore -> do
         GHCi.servWithCustom verbose hook pipe restore dbgInterpCmdHandler
 #else
       uninterruptibleMask $ GHCi.serv verbose hook pipe

--- a/test/golden/T169/T169b.ghc-1001.hdb-stdout
+++ b/test/golden/T169/T169b.ghc-1001.hdb-stdout
@@ -1,9 +1,7 @@
 [1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/T169b.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[main]
 (hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 4], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 6, endLine = 8, startCol = 8, endCol = 58}}
 (hdb) Stopped at breakpoint
-(hdb) [ScopeInfo {kind = LocalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Nothing, expensive = False},ScopeInfo {kind = ModuleVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Just 2, expensive = True},ScopeInfo {kind = GlobalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Just 354, expensive = True}]
 (hdb) Debuggee writing something to stdout
-[ScopeInfo {kind = LocalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Nothing, expensive = False},ScopeInfo {kind = ModuleVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Just 2, expensive = True},ScopeInfo {kind = GlobalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Just 354, expensive = True}]
 (hdb) Debuggee writing something to stderr
 ()
 (hdb) Exiting...

--- a/test/golden/T169/T169b.ghc-914.hdb-stdout
+++ b/test/golden/T169/T169b.ghc-914.hdb-stdout
@@ -1,9 +1,7 @@
 [1 of 2] Compiling Main             ( <TEMPORARY-DIRECTORY>/T169b.hs, interpreted )[main]
 (hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 4], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 6, endLine = 8, startCol = 8, endCol = 58}}
 (hdb) Stopped at breakpoint
-(hdb) [ScopeInfo {kind = LocalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Nothing, expensive = False},ScopeInfo {kind = ModuleVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Just 2, expensive = True},ScopeInfo {kind = GlobalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 58}, numVars = Just 353, expensive = True}]
 (hdb) Debuggee writing something to stdout
-[ScopeInfo {kind = LocalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Nothing, expensive = False},ScopeInfo {kind = ModuleVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Just 2, expensive = True},ScopeInfo {kind = GlobalVariablesScope, sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/T169b.hs", startLine = 8, endLine = 8, startCol = 3, endCol = 58}, numVars = Just 353, expensive = True}]
 (hdb) Debuggee writing something to stderr
 ()
 (hdb) Exiting...

--- a/test/golden/T169/T169b.hdb-test
+++ b/test/golden/T169/T169b.hdb-test
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-$HDB -v0 T169b.hs < T169b.hdb-stdin 2>&1
+# We don't care to see ScopeInfos when we stop at a breakpoint, just care about
+# the debuggee outputting
+$HDB -v0 T169b.hs < T169b.hdb-stdin 2>&1 | grep -v 'ScopeInfo'

--- a/test/golden/T218/T218.ghc-1001.hdb-stdout
+++ b/test/golden/T218/T218.ghc-1001.hdb-stdout
@@ -6,6 +6,6 @@
 (hdb) True
 (hdb) False
 (hdb) Aborted: <interactive>:1:1: error: [GHC-87110]
-    Could not find module ‘Does.Not.Exist’.
+    Could not find module `Does.Not.Exist'.
     Use -v to see a list of the files searched for.
 (hdb) Exiting...

--- a/test/golden/T225b/T225b.ghc-1001.hdb-stdout
+++ b/test/golden/T225b/T225b.ghc-1001.hdb-stdout
@@ -1,6 +1,6 @@
 [1 of 2] Compiling B                ( <TEMPORARY-DIRECTORY>/B.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/B.gbc )[main]
 [2 of 2] Compiling A                ( <TEMPORARY-DIRECTORY>/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/A.gbc )[main]
-(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId B 3], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/./B.hs", startLine = 11, endLine = 11, startCol = 3, endCol = 19}}
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId B 3], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/B.hs", startLine = 11, endLine = 11, startCol = 3, endCol = 19}}
 (hdb) 1
 Stopped at breakpoint
 (hdb) "fromList [1,2,3]"

--- a/test/golden/T283/T283.ghc-1001.hdb-stdout
+++ b/test/golden/T283/T283.ghc-1001.hdb-stdout
@@ -3,7 +3,7 @@
 (hdb) THIS IS A PACKAGE
 ()
 (hdb) Aborted: <interactive>:1:1: error: [GHC-35235]
-    Could not find module ‘Main’.
+    Could not find module `Main'.
     It is not a module in the current program, or in any known package.
 (hdb) "If an older version of T283 was installed, we'd now shadow the home-unit Main with the outdated installed Main!"
 (hdb) Exiting...

--- a/test/golden/exceptions-uncaught/exceptions-uncaught.ghc-1001.hdb-stdout
+++ b/test/golden/exceptions-uncaught/exceptions-uncaught.ghc-1001.hdb-stdout
@@ -6,7 +6,12 @@ Stopped at breakpoint
 Exception: ErrorCall
 Message: boom while handling
 Call stack:
-  While handling boom outer
+  While handling ghc-internal:GHC.Internal.Exception.ErrorCall:
+    |
+    | boom outer
+    |
+    | HasCallStack backtrace:
+    |   error, called at <TEMPORARY-DIRECTORY>/prog/Main.hs:8:10 in main:Main
   
   HasCallStack backtrace:
     error, called at <TEMPORARY-DIRECTORY>/prog/Main.hs:14:3 in main:Main

--- a/test/golden/standalone-multi-module/standalone-multi-module.ghc-1001.hdb-stdout
+++ b/test/golden/standalone-multi-module/standalone-multi-module.ghc-1001.hdb-stdout
@@ -1,7 +1,7 @@
 [1 of 3] Compiling Helper           ( <TEMPORARY-DIRECTORY>/Helper.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Helper.gbc )[main]
 [2 of 3] Compiling Main             ( <TEMPORARY-DIRECTORY>/Main.hs, <TEMPORARY-DIRECTORY>/.hdb-cache/<CACHE-ENTRY>/Main.gbc )[main]
 (hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Main 5], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/Main.hs", startLine = 7, endLine = 7, startCol = 3, endCol = 25}}
-(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Helper 4], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/./Helper.hs", startLine = 5, endLine = 5, startCol = 3, endCol = 38}}
+(hdb) BreakFound {changed = True, breakId = [InternalBreakpointId Helper 4], sourceSpan = SourceSpan {file = "<TEMPORARY-DIRECTORY>/Helper.hs", startLine = 5, endLine = 5, startCol = 3, endCol = 38}}
 (hdb) Stopped at breakpoint
 (hdb) Starting...
 Stopped at breakpoint

--- a/test/haskell/Test/Integration/StackTrace.hs
+++ b/test/haskell/Test/Integration/StackTrace.hs
@@ -10,6 +10,9 @@ import Test.Tasty.HUnit
 #ifdef mingw32_HOST_OS
 import Test.Tasty.ExpectedFailure
 #endif
+#if __GLASGOW_HASKELL__ >= 1001
+import Test.Tasty.ExpectedFailure
+#endif
 import qualified Data.Text as Text
 import DAP (threadId, stackFrameName)
 
@@ -19,7 +22,11 @@ stackTraceTests =
   ignoreTestBecause "Needs to be fixed for Windows (#199)" $
 #endif
   testGroup "DAP.Integration.StackTrace"
-    [ testCase "contains mixed IPE and breakpoint frames (issue #107)" mixedFramesTest
+    [
+#if __GLASGOW_HASKELL__ >= 1001
+      expectFailBecause "Needs to be fixed upstream ASAP (#27749): the thenDo continuation is getting assigned a `bindIO` source location" $
+#endif
+      testCase "contains mixed IPE and breakpoint frames (issue #107)" mixedFramesTest
     , testCase "displays stack annotation frames (issue #159)" stackAnnotationsTest
     ]
 

--- a/test/haskell/Test/Integration/StackTrace.hs
+++ b/test/haskell/Test/Integration/StackTrace.hs
@@ -10,9 +10,6 @@ import Test.Tasty.HUnit
 #ifdef mingw32_HOST_OS
 import Test.Tasty.ExpectedFailure
 #endif
-#if __GLASGOW_HASKELL__ >= 1001
-import Test.Tasty.ExpectedFailure
-#endif
 import qualified Data.Text as Text
 import DAP (threadId, stackFrameName)
 
@@ -22,11 +19,7 @@ stackTraceTests =
   ignoreTestBecause "Needs to be fixed for Windows (#199)" $
 #endif
   testGroup "DAP.Integration.StackTrace"
-    [
-#if __GLASGOW_HASKELL__ >= 1001
-      expectFailBecause "Needs to be fixed upstream ASAP (#27749): the thenDo continuation is getting assigned a `bindIO` source location" $
-#endif
-      testCase "contains mixed IPE and breakpoint frames (issue #107)" mixedFramesTest
+    [ testCase "contains mixed IPE and breakpoint frames (issue #107)" mixedFramesTest
     , testCase "displays stack annotation frames (issue #159)" stackAnnotationsTest
     ]
 


### PR DESCRIPTION
- **Use hie-bios from master on cabal.project**
- **Testsuite fixes for GHC 10.2**
- **Add verbosity to ext-interp options**
- **Render debugger messages as is, instead of showing them**
- **Re-enable -finfo-table-map since fix landed**
- **Display downsweep errors to the users too**
- **Don't write .hi and .gbc files for in-memory modules**
- **test: Ignore StackTrace failure bc ghc#27749**
