### PR TITLE
cli: Error out when entryFile does not exist

### DIFF
--- a/hdb/Development/Debug/Interactive.hs
+++ b/hdb/Development/Debug/Interactive.hs
@@ -53,11 +53,17 @@ runIDM :: LogAction IO InteractiveLog
        -> RunDebuggerSettings
        -> InteractiveDM a
        -> IO a
-runIDM logger entryPoint entryFile entryArgs extraGhcArgs cradleFile runConf act = do
-  projectRoot <- mkAbsolute <$> getCurrentDirectory
+runIDM logger runEntryPoint entryFile runEntryArgs extraGhcArgs cradleFile runConf act = do
+  runProjectRoot <- mkAbsolute <$> getCurrentDirectory
 
   let hieBiosLogger = contramap ISessionSetupLog logger
-  hieDebugRunner hieBiosLogger (DebugRunnerConf (unAbs projectRoot) entryFile extraGhcArgs cradleFile) >>= \case
+  let runEntryFile = runProjectRoot /> entryFile
+
+  entryFileExists <- doesFileExist (unAbs runEntryFile)
+  when (not entryFileExists) $ do
+    exitWithMsg $ "Entry file \"" ++ (unAbs runEntryFile) ++ "\" does not exist or is a directory."
+
+  hieDebugRunner hieBiosLogger (DebugRunnerConf (unAbs runProjectRoot) entryFile extraGhcArgs cradleFile) >>= \case
     Left e               -> exitWithMsg e
     Right (_ghcInvocation, debugRunner)
                          -> do
@@ -66,7 +72,7 @@ runIDM logger entryPoint entryFile entryArgs extraGhcArgs cradleFile runConf act
       runDebugger debugRec debugRunner runConf $
         fmap fst $
           evalRWST (runInputT (setComplete noCompletion defaultSettings) act)
-                   (RunOptions { runProjectRoot = projectRoot, runEntryFile = projectRoot /> entryFile, runEntryPoint = entryPoint, runEntryArgs = entryArgs })
+                   (RunOptions { runProjectRoot, runEntryFile, runEntryPoint, runEntryArgs })
                    (RunContext { runLastCommand = Nothing, runCurrentThread = Nothing } )
   where
     exitWithMsg txt = do

--- a/test/golden/T358/T358.ghc-1001.hdb-stdout
+++ b/test/golden/T358/T358.ghc-1001.hdb-stdout
@@ -1,0 +1,1 @@
+Entry file "<TEMPORARY-DIRECTORY>/app/Main.hs" does not exist or is a directory.

--- a/test/golden/T358/T358.hdb-test
+++ b/test/golden/T358/T358.hdb-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Running hdb on a non-existent entry file should yield readable error and not
+# something internal/inscrutable down the line
+$HDB -v0 app/Main.hs 2>&1 || true


### PR DESCRIPTION
Before this commit, we went straight to hie-bios which would fail with
an inscrutable "Couldn't execute ghc --numeric-version" when the file
didn't exist.

Fixes #358
